### PR TITLE
Implement lazy boot and chat API

### DIFF
--- a/vgj_chat/__init__.py
+++ b/vgj_chat/__init__.py
@@ -1,5 +1,11 @@
 """VGJ Chat package."""
 
 from .config import CFG
+from .models import rag
 
-__all__ = ["CFG"]
+
+def chat(question: str) -> str:
+    """Return an answer to *question* using the RAG model."""
+    return rag.chat(question)
+
+__all__ = ["CFG", "chat"]

--- a/vgj_chat/ui/gradio_app.py
+++ b/vgj_chat/ui/gradio_app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import gradio as gr
 
-from ..models.rag import answer_stream
+from ..models.rag import _ensure_boot, answer_stream
 
 
 def user_submit(msg: str, hist: list[dict[str, str]]):
@@ -14,6 +14,7 @@ page_title = "Unofficial Visit\u00a0Grand\u00a0Junction\u00a0Demo – not endors
 
 
 def build_demo() -> gr.Blocks:
+    _ensure_boot()
     with gr.Blocks(theme=gr.themes.Soft(), title=page_title) as demo:
         gr.Markdown(
             (


### PR DESCRIPTION
## Summary
- lazily load heavy resources in the rag model
- initialise models when the CLI starts
- expose a top-level `vgj_chat.chat()` helper

## Testing
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f111529908323ac3874870c47bd64