### PR TITLE
Add config overrides via env or CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,20 @@ Launch the Gradio demo with:
 ```bash
 python -m vgj_chat
 ```
+
+## Configuration
+
+Configuration defaults live in `vgj_chat.config.Config`.  Any field can be
+overridden by environment variables prefixed with `VGJ_` or by passing a
+command-line option of the same name.
+
+Environment variables use upper-case field names, for example
+`VGJ_INDEX_PATH` overrides `index_path`.
+
+Command-line overrides replace underscores with dashes, e.g.:
+
+```bash
+python -m vgj_chat --index-path my.index --top-k 3
+```
+
+Both methods may be combined; CLI options take precedence.

--- a/vgj_chat/cli.py
+++ b/vgj_chat/cli.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 import argparse
 
-from .ui.gradio_app import demo
+from .config import CFG, Config
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="VGJ Chat demo")
-    _ = parser.parse_args(argv)
+    Config.add_argparse_args(parser)
+    args = parser.parse_args(argv)
+
+    global CFG
+    CFG = CFG.apply_cli_args(args)
+
+    from .ui.gradio_app import build_demo
+
+    demo = build_demo()
     demo.queue()
     demo.launch()
 

--- a/vgj_chat/ui/gradio_app.py
+++ b/vgj_chat/ui/gradio_app.py
@@ -43,6 +43,3 @@ def build_demo() -> gr.Blocks:
             outputs=[chatbox, chat_state],
         )
     return demo
-
-
-demo = build_demo()


### PR DESCRIPTION
## Summary
- make `vgj_chat.config.Config` load defaults and allow environment variable overrides
- expose helpers to add/parse CLI arguments
- update CLI to parse options before building the Gradio demo
- stop building the demo at import time
- document configuration options

## Testing
- `python -m compileall vgj_chat`

------
https://chatgpt.com/codex/tasks/task_e_687f120538208323b930ab1c4298a0de