### PR TITLE
Fix crawler url output and enable GPU runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM pytorch/pytorch:2.2.2-cuda12.1-cudnn8-runtime
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vgj_chat"
 version = "0.1.0"
 description = "RAG chatbot using a LoRA adapted language model"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 dependencies = [
     "gradio",

--- a/vgj_chat/data/crawl.py
+++ b/vgj_chat/data/crawl.py
@@ -153,6 +153,7 @@ async def worker(
         text = soup.get_text(" ", strip=True)
         if text:
             (DATA_DIR_TXT / f"{uid}.txt").write_text(text)
+            (DATA_DIR_TXT / f"{uid}.url").write_text(url)
             (RAW_HTML_DIR / f"{uid}.html").write_bytes(body)
         else:
             (NO_TEXT_HTML_DIR / f"{uid}.html").write_bytes(body)


### PR DESCRIPTION
## Summary
- record page URL when crawling so the indexer can read it
- target CUDA-enabled PyTorch base image
- relax Python requirement to >=3.10

## Testing
- `make format`
- `ruff check .`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f2519c6648323b4b5c3ede61c6962