### PR TITLE
Remove unused nltk import

### DIFF
--- a/vgj_chat/data/dataset.py
+++ b/vgj_chat/data/dataset.py
@@ -7,10 +7,7 @@ import re
 from pathlib import Path
 
 import bs4
-import nltk
 import torch
-from datasets import load_dataset
-from sentence_transformers import SentenceTransformer
 from tqdm.auto import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 


### PR DESCRIPTION
## Summary
- delete the unused `nltk` import from `dataset.py`
- clean up other unused imports so that `ruff` shows no unused-import warnings

## Testing
- `ruff check vgj_chat/data/dataset.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2a5e56e48323ab47a73a4e16ea21