### PR TITLE
Fix NLTK data missing for index build

### DIFF
--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,8 +1,17 @@
+"""Utility to build the FAISS index used for retrieval."""
+
 from pathlib import Path
 
-from vgj_chat.data.index import CHUNK_TOKENS, OVERLAP_TOKENS, build_index
+import nltk
+
+from vgj_chat.data.index import build_index
 
 if __name__ == "__main__":
+    for res in ("punkt", "punkt_tab"):
+        try:
+            nltk.data.find(f"tokenizers/{res}")
+        except LookupError:
+            nltk.download(res, quiet=True)
     build_index(
         Path("data/html_txt"),
         Path("faiss.index"),


### PR DESCRIPTION
## Summary
- ensure NLTK tokeniser data is available when building the FAISS index

## Testing
- `ruff check scripts/build_index.py`
- `black --check scripts/build_index.py`
- `isort --check-only scripts/build_index.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2930d94c83239c37c42b48fbd22e