### PR TITLE
Add bitsandbytes dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ pipx run hatch env create
 pipx run hatch run python -m vgj_chat
 ```
 
+## Dependencies
+
+The application requires `bitsandbytes` in addition to the standard
+dependencies listed in `pyproject.toml`.
+
 ## Docker
 
 A Dockerfile is provided for a fully containerised setup. Building the image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "faiss-cpu",
     "sentence-transformers",
     "torch",
+    "bitsandbytes",
     "peft",
     "datasets",
     "scikit-learn",


### PR DESCRIPTION
## Summary
- add `bitsandbytes` to runtime dependencies
- document the requirement in the README

## Testing
- `pip install -e .` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687fb321adfc8323b472619e7ee9ec2d