### PR TITLE
Add optional HF token login

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ organised as a Python package named `vgj_chat`.
 Launch the Gradio demo with:
 
 ```bash
-python -m vgj_chat
+python -m vgj_chat --hf-token <HF_TOKEN>
 ```
 
 ## Quick start
@@ -15,7 +15,7 @@ Create a local environment with [Hatch](https://hatch.pypa.io/) and run the demo
 
 ```bash
 pipx run hatch env create
-pipx run hatch run python -m vgj_chat
+pipx run hatch run python -m vgj_chat --hf-token <HF_TOKEN>
 ```
 
 ## Dependencies
@@ -57,7 +57,7 @@ Environment variables use upper-case field names, for example
 Command-line overrides replace underscores with dashes, e.g.:
 
 ```bash
-python -m vgj_chat --index-path my.index --top-k 3
+python -m vgj_chat --hf-token <HF_TOKEN> --index-path my.index --top-k 3
 ```
 
 Both methods may be combined; CLI options take precedence.

--- a/vgj_chat/config.py
+++ b/vgj_chat/config.py
@@ -35,6 +35,9 @@ class Config:
     cuda: bool = torch.cuda.is_available()
     debug: bool = True
 
+    # authentication
+    hf_token: str | None = None
+
     @staticmethod
     def _convert(value: str, typ: type):
         """Convert *value* to *typ* for overrides."""

--- a/vgj_chat/models/rag.py
+++ b/vgj_chat/models/rag.py
@@ -6,6 +6,7 @@ from typing import Generator, List, Tuple
 
 import faiss  # type: ignore
 import torch  # type: ignore
+from huggingface_hub import login
 from peft import PeftModel  # type: ignore
 from sentence_transformers import CrossEncoder, SentenceTransformer
 from transformers import (
@@ -41,6 +42,8 @@ def _boot() -> tuple[
     CrossEncoder,
     pipeline,
 ]:
+    if CFG.hf_token is not None:
+        login(token=CFG.hf_token)
     logger.info("Loading FAISS index and metadata …")
     index = load_index(CFG.index_path)
     texts, urls = load_metadata(CFG.meta_path)


### PR DESCRIPTION
## Summary
- add an optional `hf_token` field to the configuration
- login to Hugging Face when `hf_token` is provided
- document new `--hf-token` flag in README

## Testing
- `make format`
- `ruff check .`
- `make test` *(fails: ModuleNotFoundError: huggingface_hub)*

------
https://chatgpt.com/codex/tasks/task_e_687fb9cda9d883239a67e09d6c094518