### PR TITLE
Add artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ build/
 dist/
 *.egg-info/
 
+# Ignore runtime artifacts
+data/
+faiss.index
+meta.jsonl
+*.env


### PR DESCRIPTION
## Summary
- expand `.gitignore` with dataset and runtime artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'huggingface_hub')*

------
https://chatgpt.com/codex/tasks/task_e_687fbd448ecc832388de26a3c0ff9221