### PR TITLE
Use load_index in gradio boot

### DIFF
--- a/gradio_vgj_chat.py
+++ b/gradio_vgj_chat.py
@@ -28,6 +28,8 @@ from transformers import (
     pipeline,
 )
 
+from vgj_chat.data.io import load_index
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 #  Configuration
@@ -106,7 +108,7 @@ def _boot() -> tuple[
     pipeline,
 ]:
     logger.info("Loading FAISS index and metadata …")
-    index: faiss.Index = faiss.read_index(str(CFG.index_path))
+    index: faiss.Index = load_index(CFG.index_path)
     raw_meta = [json.loads(l) for l in CFG.meta_path.read_text().splitlines()]
     texts = [_clean(m["text"]) for m in raw_meta]  # ← pre‑filter once
     urls = [m["url"] for m in raw_meta]


### PR DESCRIPTION
## Summary
- use helper load_index to load FAISS index with optional GPU
- tidy imports

## Testing
- `isort gradio_vgj_chat.py`
- `black gradio_vgj_chat.py`
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc0cbbf2c8323a67816e7cd6c2b13