### PR TITLE
Add FAISS GPU stubs for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,16 @@ for mod_name in ["faiss", "sentence_transformers", "transformers", "peft", "grad
 
 # faiss helpers used in code
 sys.modules["faiss"].read_index = lambda *a, **k: None
+sys.modules["faiss"].get_num_gpus = lambda: 0
+
+
+class DummyStandardGpuResources:
+    def __init__(self, *a, **k):
+        pass
+
+
+sys.modules["faiss"].StandardGpuResources = DummyStandardGpuResources
+sys.modules["faiss"].index_cpu_to_gpu = lambda res, device, index: index
 
 sys.modules["sentence_transformers"].CrossEncoder = object
 sys.modules["sentence_transformers"].SentenceTransformer = object


### PR DESCRIPTION
## Summary
- stub `faiss.get_num_gpus` and GPU helpers in tests
- ensure FAISS index loading works without GPU

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687fc19ded1883238c40c0c272081bff