### PR TITLE
Disable debug by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Command-line overrides replace underscores with dashes, e.g.:
 python -m vgj_chat --hf-token <HF_TOKEN> --index-path my.index --top-k 3
 ```
 
+Debug logging is disabled by default. Enable it with `--debug true` or set
+`VGJ_DEBUG=true` in the environment.
+
 Both methods may be combined; CLI options take precedence.
 
 ## Development

--- a/gradio_vgj_chat.py
+++ b/gradio_vgj_chat.py
@@ -56,7 +56,7 @@ class Config:
 
     # misc
     cuda: bool = torch.cuda.is_available()
-    debug: bool = True
+    debug: bool = False
 
 
 CFG = Config()

--- a/vgj_chat/config.py
+++ b/vgj_chat/config.py
@@ -33,7 +33,7 @@ class Config:
 
     # misc
     cuda: bool = torch.cuda.is_available()
-    debug: bool = True
+    debug: bool = False
 
     # authentication
     hf_token: str | None = None

--- a/vgj_chat/models/rag.py
+++ b/vgj_chat/models/rag.py
@@ -30,11 +30,20 @@ from ..data.io import load_index, load_metadata
 from .guards import too_similar
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format="%(asctime)s | %(levelname)-8s | %(message)s",
-    level=logging.DEBUG if CFG.debug else logging.INFO,
-    datefmt="%H:%M:%S",
-)
+
+
+def _configure_logging() -> None:
+    """Configure logging based on :data:`CFG.debug`."""
+    level = logging.DEBUG if CFG.debug else logging.INFO
+    logging.basicConfig(
+        format="%(asctime)s | %(levelname)-8s | %(message)s",
+        level=level,
+        datefmt="%H:%M:%S",
+    )
+    logger.setLevel(level)
+
+
+_configure_logging()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- default the Config `debug` flag to `False`
- sync the standalone `gradio_vgj_chat.py` script with the new default
- rework logging setup in `models.rag` so it always honours `CFG.debug`
- document how to enable debug logging via CLI or env var

## Testing
- `make format`
- `ruff check .`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687fce8d3b348323b3c514b59bdc89bb