### PR TITLE
Fix LoRA path handling

### DIFF
--- a/gradio_vgj_chat.py
+++ b/gradio_vgj_chat.py
@@ -132,7 +132,7 @@ def _boot() -> tuple[
         device_map="auto",
         torch_dtype=torch.float16,
     )
-    lora = PeftModel.from_pretrained(base, CFG.lora_dir)
+    lora = PeftModel.from_pretrained(base, str(CFG.lora_dir))
     merged = lora.merge_and_unload()
 
     chat_pipe = pipeline(

--- a/vgj_chat/models/rag.py
+++ b/vgj_chat/models/rag.py
@@ -84,7 +84,7 @@ def _boot() -> tuple[
         device_map="auto",
         torch_dtype=torch.float16,
     )
-    lora = PeftModel.from_pretrained(base, CFG.lora_dir)
+    lora = PeftModel.from_pretrained(base, str(CFG.lora_dir))
     merged = lora.merge_and_unload()
 
     chat_pipe = pipeline(


### PR DESCRIPTION
## Summary
- ensure LoRA checkpoint directory is converted to string when loading
- same fix for the standalone `gradio_vgj_chat.py`

## Testing
- `make format`
- `ruff check .`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687fda8598408323a88f8cb42c7f2c69