### PR TITLE
Install CUDA wheels for FAISS and bitsandbytes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,19 @@ FROM pytorch/pytorch:2.2.2-cuda12.1-cudnn8-runtime
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . .
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir \
+        faiss-gpu \
+        bitsandbytes && \
+    pip install --no-cache-dir .
 
 RUN python scripts/crawl.py && \
     python scripts/build_index.py

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ pipx run hatch env create
 pipx run hatch run python -m vgj_chat --hf-token <HF_TOKEN>
 ```
 The environment installs the GPU-enabled FAISS package so the demo can
-use the GPU when available.
+use the GPU when available.  The Docker image installs the
+CUDA-enabled `bitsandbytes` and `faiss-gpu` wheels.  If a matching wheel
+isn't available for your Python or CUDA version you will need the
+`cuda-toolkit` headers to compile them from source (e.g.
+`apt install cuda-toolkit-12-1`).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- install CUDA-enabled `faiss-gpu` and `bitsandbytes` wheels in Docker
- document CUDA toolkit requirement if no wheel is available

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687fdc1fae7083238e4d3feeb9a32b64