### PR TITLE
Update Docker base to CUDA 12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.2.2-cuda12.4-cudnn8-devel
+FROM pytorch/pytorch:2.2.2-cuda12.1-cudnn8-devel
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use the GPU when available.  The Docker image installs the
 CUDA-enabled `bitsandbytes` and `faiss-gpu` wheels.  If a matching wheel
 isn't available for your Python or CUDA version you will need the
 `cuda-toolkit` headers to compile them from source (e.g.
-`apt install cuda-toolkit-12-4`).
+`apt install cuda-toolkit-12-1`).
 
 ## Dependencies
 
@@ -55,8 +55,9 @@ available.
 
 ## Docker
 
-A Dockerfile is provided for a fully containerised setup. Building the image
-will run the crawler and indexer so the demo is ready to launch:
+A Dockerfile is provided for a fully containerised setup. The image
+uses the PyTorch 2.2.2 base with CUDA 12.1 and cuDNN 8. Building it will
+run the crawler and indexer so the demo is ready to launch:
 
 ```bash
 docker build -t vgj-chat .


### PR DESCRIPTION
## Summary
- use CUDA 12.1 pytorch base image
- clarify CUDA version in the Docker section of the README
- adjust CUDA toolkit install command

## Testing
- `pytest -q`
- `docker build -t vgj-chat .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff35534248323bd9f525ed862b3f1