### PR TITLE
Update CUDA base info in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use the GPU when available.  The Docker image installs the
 CUDA-enabled `bitsandbytes` and `faiss-gpu-cu12` wheels.  If a matching wheel
 isn't available for your Python or CUDA version you will need the
 `cuda-toolkit` headers to compile them from source (e.g.
-`apt install cuda-toolkit-12-1`).
+`apt install cuda-toolkit-12-8`).
 
 ## Dependencies
 
@@ -56,7 +56,7 @@ available.
 ## Docker
 
 A Dockerfile is provided for a fully containerised setup. The image
-uses the PyTorch 2.2.2 base with CUDA 12.1 and cuDNN 8. Building it will
+uses the PyTorch 2.7.1 base with CUDA 12.8 and cuDNN 9. Building it will
 run the crawler and indexer so the demo is ready to launch:
 
 ```bash


### PR DESCRIPTION
## Summary
- note that `pytorch:2.7.1-cuda12.8-cudnn9-runtime` is the Docker base
- update CUDA toolkit hint to `cuda-toolkit-12-8`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880369c78008323b60a525042dc3482