### PR TITLE
Improve GPU fallback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ docker build -t vgj-chat .
 docker run --gpus all -p 7860:7860 -e VGJ_HF_TOKEN=<token> vgj-chat
 ```
 
+### GPU compatibility issues
+
+If the container exits with an error similar to:
+
+```
+Faiss assertion 'err__ == cudaSuccess' ... CUDA error 209 no kernel image is available for execution on the device
+```
+
+the FAISS wheel was built for a GPU architecture that does not match your hardware.
+Run the demo on the CPU by disabling CUDA:
+
+```bash
+docker run -p 7860:7860 -e VGJ_HF_TOKEN=<token> -e VGJ_CUDA=false vgj-chat
+```
+
+Rebuilding the Docker image with FAISS compiled for your GPU will enable GPU acceleration.
+
 ## Architecture
 
 ```

--- a/vgj_chat/data/io.py
+++ b/vgj_chat/data/io.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import List, Tuple
 
+import logging
+
 import faiss  # type: ignore
 
 from ..config import CFG
@@ -28,6 +30,9 @@ def clean(text: str) -> str:
     return "\n".join(cleaned_lines).strip()
 
 
+logger = logging.getLogger(__name__)
+
+
 def load_index(path: Path) -> faiss.Index:
     """Load a FAISS index from *path* using GPU when available."""
 
@@ -37,8 +42,8 @@ def load_index(path: Path) -> faiss.Index:
         try:
             res = faiss.StandardGpuResources()
             index = faiss.index_cpu_to_gpu(res, 0, index)
-        except Exception:
-            pass
+        except Exception as exc:  # pragma: no cover - GPU runtime errors
+            logger.warning("Falling back to CPU index due to GPU error: %s", exc)
 
     return index
 


### PR DESCRIPTION
## Summary
- warn if FAISS GPU initialisation fails and keep using CPU index
- document how to disable CUDA in Docker when FAISS fails

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880375ee0a08323aa76e5f49b35433f