### PR TITLE
Install compiler tools in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
+    apt-get install -y --no-install-recommends git build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # ----- dependency layer -----

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ A Dockerfile is provided for a fully containerised setup. The image
 uses the PyTorch 2.7.1 base with CUDA 12.8 and cuDNN 9. Building it will
 run the crawler and indexer so the demo is ready to launch:
 
+The image also installs `build-essential` so a C/C++ compiler is available for
+dependencies like `bitsandbytes` and the Triton runtime.
+
 ```bash
 docker build -t vgj-chat .
 # GPU acceleration requires the host to install the NVIDIA Container Toolkit


### PR DESCRIPTION
## Summary
- update Dockerfile to install build-essential
- document compiler requirement in README

## Testing
- `PYTHONPATH=. pytest -q`
- `docker build -t vgj-chat .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6880425b96c88323bbe363659ae7ce96