### PR TITLE
Use exponential backoff in fetch()

### DIFF
--- a/vgj_chat/data/crawl.py
+++ b/vgj_chat/data/crawl.py
@@ -121,7 +121,7 @@ async def fetch(
                     mime = r.headers.get("content-type", "text/html").split(";")[0]
                     return mime, await r.read()
         except Exception:
-            await asyncio.sleep(BACKOFF_FACTOR * attempt)
+            await asyncio.sleep(BACKOFF_FACTOR ** attempt)
     return None, b""
 
 


### PR DESCRIPTION
## Summary
- implement exponential backoff delay for crawler fetch retries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804ca9fc9c8323a5ae5b6ae6ceaa7f