### PR TITLE
Add crawl limit and index cap flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ application on the GPU.
 Run the helper scripts in order to create the training data, fine‑tune the
 LoRA adapter and start the chat demo:
 
-1. `python scripts/crawl.py`
-2. `python scripts/build_index.py`
+1. `python scripts/crawl.py` (pass `--limit 20` to download only the first
+   twenty pages for debugging)
+2. `python scripts/build_index.py` (use `--limit 20` to index only the downloaded
+   debug pages)
 3. `python scripts/build_dataset.py`
 4. `python scripts/finetune.py`
 5. `python -m vgj_chat`

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,5 +1,6 @@
 """Utility to build the FAISS index used for retrieval."""
 
+import argparse
 from pathlib import Path
 
 import nltk
@@ -7,6 +8,15 @@ import nltk
 from vgj_chat.data.index import build_index
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build FAISS index")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of documents to index",
+    )
+    args = parser.parse_args()
+
     for res in ("punkt", "punkt_tab"):
         try:
             nltk.data.find(f"tokenizers/{res}")
@@ -17,4 +27,5 @@ if __name__ == "__main__":
         Path("faiss.index"),
         Path("meta.jsonl"),
         "sentence-transformers/all-MiniLM-L6-v2",
+        max_docs=args.limit,
     )

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 
 from vgj_chat.data.crawl import (
@@ -9,7 +10,16 @@ from vgj_chat.data.crawl import (
 )
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run crawler")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of pages to download",
+    )
+    args = parser.parse_args()
+
     seed = asyncio.run(
         sitemap_seed(BASE_URL, internal_set(BASE_URL, ADDITIONAL_DOMAINS))
     )
-    asyncio.run(crawl(seed))
+    asyncio.run(crawl(seed, limit=args.limit))


### PR DESCRIPTION
## Summary
- add optional `--limit` flag to crawl script
- support limiting number of documents in the crawler and index builder
- update README with debug instructions

## Testing
- `ruff check scripts/build_index.py scripts/crawl.py vgj_chat/data/crawl.py vgj_chat/data/index.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880558c90448323b4fff1915a9b8e96