### PR TITLE
Enable HF token for dataset and finetune scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ LoRA adapter and start the chat demo:
 4. `python scripts/finetune.py`
 5. `python -m vgj_chat`
 
-The base model requires an access token. Pass it with `--hf-token` or set the
-`VGJ_HF_TOKEN` environment variable. A CUDA‑enabled GPU is recommended for the
-indexing and fine‑tuning steps and should have at least 16 GB of memory.
+The base model requires an access token. Set the token in `VGJ_HF_TOKEN` (or
+pass `--hf-token` when launching the chat). The helper scripts read the same
+variable so ensure it is exported before running them. A CUDA‑enabled GPU is
+recommended for the indexing and fine‑tuning steps and should have at least
+16 GB of memory.
 
 ## LoRA adapter
 

--- a/vgj_chat/data/dataset.py
+++ b/vgj_chat/data/dataset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from datasets import load_dataset
 from sentence_transformers import SentenceTransformer
 from tqdm.auto import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from huggingface_hub import login
 
 LLM_NAME = "mistralai/Mistral-7B-Instruct-v0.2"
 PARA_MAX = 3
@@ -31,12 +33,18 @@ quant_cfg = BitsAndBytesConfig(
     bnb_4bit_use_double_quant=True,
 )
 
-tok = AutoTokenizer.from_pretrained(LLM_NAME, use_fast=True)
+# authenticate for gated base model if token available
+HF_TOKEN = os.getenv("VGJ_HF_TOKEN")
+if HF_TOKEN:
+    login(token=HF_TOKEN)
+
+tok = AutoTokenizer.from_pretrained(LLM_NAME, use_fast=True, token=HF_TOKEN)
 llm = AutoModelForCausalLM.from_pretrained(
     LLM_NAME,
     quantization_config=quant_cfg,
     torch_dtype=torch.float16,
     device_map={"": 0},
+    token=HF_TOKEN,
 )
 
 


### PR DESCRIPTION
## Summary
- authenticate to Hugging Face when building the dataset or fine‑tuning
- document that `VGJ_HF_TOKEN` must be exported before running helper scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688059c9ad0083238baa5f7986ea1fc7