### PR TITLE
Add missing trl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ isn't available for your Python or CUDA version you will need the
 
 The application requires `bitsandbytes` and the GPU-enabled `faiss-gpu-cu12`
 package in addition to the standard dependencies listed in `pyproject.toml`.
+The LoRA fine‑tuning script also depends on the `trl` library which provides
+`SFTTrainer`.
 
 
 FAISS uses the GPU by default when available. Set `VGJ_FAISS_CUDA=false` or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "datasets",
     "scikit-learn",
     "transformers",
+    "trl",
     "nltk",
     "tqdm",
     "numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ faiss-gpu-cu12==1.8.0.2
 bitsandbytes==0.45.5
 accelerate==1.6.0
 git+https://github.com/huggingface/transformers.git@v4.51.0
+trl


### PR DESCRIPTION
## Summary
- install `trl` for LoRA fine-tuning
- document `trl` requirement

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880636364a88323abcc031eea91c596