### PR TITLE
Fix Docker build authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
 
+# Optional Hugging Face token for accessing gated models during build
+ARG HF_TOKEN
+ENV VGJ_HF_TOKEN=${HF_TOKEN}
+
 WORKDIR /app
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ The image also installs `build-essential` so a C/C++ compiler is available for
 dependencies like `bitsandbytes` and the Triton runtime.
 
 ```bash
-docker build -t vgj-chat .
+# pass your Hugging Face token so the helper scripts can download the gated
+# base model during the build
+docker build --build-arg HF_TOKEN=<token> -t vgj-chat .
 # GPU acceleration requires the host to install the NVIDIA Container Toolkit
 # and have compatible NVIDIA drivers. Run the container with:
 docker run --gpus all -p 7860:7860 -e VGJ_HF_TOKEN=<token> vgj-chat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,8 @@ extend-exclude = [
   "vgj_chat/models/*",
 ]
 
+[tool.setuptools.packages.find]
+include = ["vgj_chat*"]
+
 [tool.pytest.ini_options]
 addopts = "-ra"


### PR DESCRIPTION
## Summary
- allow passing a Hugging Face access token during docker build
- explain the new build arg in the README
- restrict setuptools package discovery to `vgj_chat`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880671e19588323badfe4f9272c70b1