### PR TITLE
Allow CPU fallback and simplify Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
 
-# Optional Hugging Face token for accessing gated models during build
-ARG HF_TOKEN
-ENV VGJ_HF_TOKEN=${HF_TOKEN}
 
 WORKDIR /app
 
@@ -19,10 +16,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 COPY . .
 RUN pip install --no-cache-dir .
 
-RUN python scripts/crawl.py --limit 20 && \
-    python scripts/build_index.py --limit 20 && \
-    python scripts/build_dataset.py && \
-    python scripts/finetune.py
 
 EXPOSE 7860
 CMD ["python", "-m", "vgj_chat"]

--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -41,21 +41,28 @@ def run_finetune() -> None:
     hf_token = os.getenv("VGJ_HF_TOKEN")
     if hf_token:
         login(token=hf_token)
-    bnb_cfg = BitsAndBytesConfig(
-        load_in_4bit=True,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.float16,
-        bnb_4bit_use_double_quant=True,
-    )
     tok = AutoTokenizer.from_pretrained(BASE_MODEL, use_fast=True, token=hf_token)
     tok.pad_token = tok.eos_token
-    base = AutoModelForCausalLM.from_pretrained(
-        BASE_MODEL,
-        quantization_config=bnb_cfg,
-        device_map={"": 0},
-        torch_dtype=torch.float16,
-        token=hf_token,
-    )
+    if torch.cuda.is_available():
+        bnb_cfg = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.float16,
+            bnb_4bit_use_double_quant=True,
+        )
+        base = AutoModelForCausalLM.from_pretrained(
+            BASE_MODEL,
+            quantization_config=bnb_cfg,
+            device_map={"": 0},
+            torch_dtype=torch.float16,
+            token=hf_token,
+        )
+    else:
+        base = AutoModelForCausalLM.from_pretrained(
+            BASE_MODEL,
+            torch_dtype=torch.float32,
+            token=hf_token,
+        )
     base = prepare_model_for_kbit_training(base)
     lora_cfg = LoraConfig(
         r=LORA_R,


### PR DESCRIPTION
## Summary
- simplify Dockerfile to only install dependencies
- enable CPU mode when CUDA is unavailable for dataset creation and finetuning
- mention CPU fallback and updated container workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806ce932a08323a7da21aaed101645