### PR TITLE
Force CPU-only FAISS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,18 @@ Run the demo with:
 pipx run hatch env create
 pipx run hatch run python -m vgj_chat --hf-token <HF_TOKEN>
 ```
-The environment installs the GPU-enabled FAISS package so the demo can
-use the GPU when available.  The Docker image installs the
-CUDA-enabled `bitsandbytes` and `faiss-gpu-cu12` wheels.  If a matching wheel
-isn't available for your Python or CUDA version you will need the
-`cuda-toolkit` headers to compile them from source (e.g.
-`apt install cuda-toolkit-12-8`).
+The environment installs the CPU-only FAISS package so the demo runs without
+requiring GPU support. The Docker image includes the CUDA-enabled
+`bitsandbytes` wheel for model inference, but FAISS always runs on the CPU,
+eliminating GPU compatibility concerns.
 
 ## Dependencies
 
-The application requires `bitsandbytes` and the GPU-enabled `faiss-gpu-cu12`
-package in addition to the standard dependencies listed in `pyproject.toml`.
-The LoRA fine‑tuning script also depends on the `trl` library which provides
-`SFTTrainer`.
-
-
-FAISS uses the GPU by default when available. Set `VGJ_FAISS_CUDA=false` or
-pass `--faiss-cuda false` to force CPU indexing while keeping the rest of the
-application on the GPU.
+The application requires `bitsandbytes` and the CPU-only `faiss-cpu` package in
+addition to the standard dependencies listed in `pyproject.toml`. The LoRA
+fine‑tuning script also depends on the `trl` library which provides
+`SFTTrainer`. FAISS always runs on the CPU so no additional configuration is
+needed.
 
 ## Preparation
 
@@ -104,23 +98,6 @@ docker exec -it <container_id> python scripts/build_dataset.py
 docker exec -it <container_id> python scripts/finetune.py
 ```
 
-### GPU compatibility issues
-
-If the container exits with an error similar to:
-
-```
-Faiss assertion 'err__ == cudaSuccess' ... CUDA error 209 no kernel image is available for execution on the device
-```
-
-the FAISS wheel was built for a GPU architecture that does not match your
-hardware. Disable FAISS GPU usage while keeping the model on the GPU with:
-
-```bash
-docker run -p 7860:7860 -e VGJ_HF_TOKEN=<token> -e VGJ_FAISS_CUDA=false vgj-chat
-```
-
-If you need FAISS acceleration, rebuild the Docker image with FAISS compiled for
-your GPU.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = {text = "MIT"}
 dependencies = [
     "gradio",
-    "faiss-gpu-cu12==1.8.0.2",
+    "faiss-cpu==1.8.0",
     "sentence-transformers",
     "torch",
     "bitsandbytes",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-faiss-gpu-cu12==1.8.0.2
+faiss-cpu==1.8.0
 bitsandbytes==0.45.5
 accelerate==1.6.0
 git+https://github.com/huggingface/transformers.git@v4.51.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,9 @@ def test_apply_cli_args():
     cfg = Config()
     parser = argparse.ArgumentParser()
     Config.add_argparse_args(parser)
-    args = parser.parse_args(["--top-k", "3", "--debug", "true", "--faiss-cuda", "false"])
+    args = parser.parse_args(
+        ["--top-k", "3", "--debug", "true", "--faiss-cuda", "false"]
+    )
     new_cfg = cfg.apply_cli_args(args)
     assert new_cfg.top_k == 3
     assert new_cfg.debug is True

--- a/vgj_chat/config.py
+++ b/vgj_chat/config.py
@@ -33,8 +33,8 @@ class Config:
 
     # misc
     cuda: bool = torch.cuda.is_available()
-    # controls GPU usage for FAISS separately from the rest of the app
-    faiss_cuda: bool = torch.cuda.is_available()
+    # FAISS always runs on the CPU
+    faiss_cuda: bool = False
     debug: bool = False
 
     # authentication

--- a/vgj_chat/data/dataset.py
+++ b/vgj_chat/data/dataset.py
@@ -10,10 +10,10 @@ from pathlib import Path
 import torch
 import trafilatura
 from datasets import load_dataset
+from huggingface_hub import login
 from sentence_transformers import SentenceTransformer
 from tqdm.auto import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
-from huggingface_hub import login
 
 LLM_NAME = "mistralai/Mistral-7B-Instruct-v0.2"
 PARA_MAX = 3

--- a/vgj_chat/data/io.py
+++ b/vgj_chat/data/io.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import List, Tuple
 
-import logging
-
 import faiss  # type: ignore
-
-from ..config import CFG
 
 FAQ_RX = re.compile(r"^[QA]:", re.I)
 FOOTER_RX = re.compile(
@@ -34,16 +31,9 @@ logger = logging.getLogger(__name__)
 
 
 def load_index(path: Path) -> faiss.Index:
-    """Load a FAISS index from *path* using GPU when available."""
+    """Load a FAISS index from *path* (CPU only)."""
 
     index = faiss.read_index(str(path))
-
-    if CFG.faiss_cuda and getattr(faiss, "get_num_gpus", lambda: 0)() > 0:
-        try:
-            res = faiss.StandardGpuResources()
-            index = faiss.index_cpu_to_gpu(res, 0, index)
-        except Exception as exc:  # pragma: no cover - GPU runtime errors
-            logger.warning("Falling back to CPU index due to GPU error: %s", exc)
 
     return index
 

--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import os
+from pathlib import Path
 
 import torch
 from datasets import load_dataset
+from huggingface_hub import login
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 from sklearn.model_selection import train_test_split
 from transformers import (
@@ -17,7 +18,6 @@ from transformers import (
     TrainingArguments,
 )
 from trl import SFTTrainer
-from huggingface_hub import login
 
 BASE_MODEL = "mistralai/Mistral-7B-Instruct-v0.2"
 # dataset built by ``vgj_chat.data.dataset.build_auto_dataset``


### PR DESCRIPTION
## Summary
- drop faiss-gpu dependency
- default FAISS to CPU in config and IO helpers
- document CPU-only FAISS usage in README

## Testing
- `make format`
- `ruff check .`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68811902673083239f9847b8612aed97