### PR TITLE
Add compare mode option

### DIFF
--- a/vgj_chat/cli.py
+++ b/vgj_chat/cli.py
@@ -2,16 +2,25 @@ from __future__ import annotations
 
 import argparse
 
+from dataclasses import replace
+
 from .config import CFG, Config
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="VGJ Chat demo")
     Config.add_argparse_args(parser)
+    parser.add_argument(
+        "-c",
+        "--compare",
+        action="store_true",
+        help="Launch UI in Compare mode",
+    )
     args = parser.parse_args(argv)
 
     global CFG
     CFG = CFG.apply_cli_args(args)
+    CFG = replace(CFG, compare_mode=args.compare)
 
     from .ui.gradio_app import build_demo
 

--- a/vgj_chat/config.py
+++ b/vgj_chat/config.py
@@ -40,6 +40,9 @@ class Config:
     # authentication
     hf_token: str | None = None
 
+    # UI mode
+    compare_mode: bool = False
+
     @staticmethod
     def _convert(value: str, typ: type):
         """Convert *value* to *typ* for overrides."""


### PR DESCRIPTION
## Summary
- add `compare_mode` field to configuration
- parse `-c/--compare` CLI option
- apply CLI flag to configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688171aa076483238d4a7def99f7332c