### PR TITLE
Add baseline generation helpers

### DIFF
--- a/vgj_chat/__init__.py
+++ b/vgj_chat/__init__.py
@@ -9,4 +9,14 @@ def chat(question: str) -> str:
     return rag.chat(question)
 
 
-__all__ = ["CFG", "chat"]
+def run_enhanced(question: str) -> str:
+    """Return an answer using the enhanced RAG pipeline."""
+    return rag.run_enhanced(question)
+
+
+def run_baseline(question: str) -> str:
+    """Return a baseline answer without retrieval or LoRA."""
+    return rag.run_baseline(question)
+
+
+__all__ = ["CFG", "chat", "run_enhanced", "run_baseline"]


### PR DESCRIPTION
## Summary
- provide baseline and enhanced generation helpers
- detach LoRA and index with a context manager
- re-export helpers in package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68817235f0e08323b25009b9fbb9f337