### PR TITLE
Improve CLI and baseline test coverage

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,26 @@
+from contextlib import contextmanager
+
+from vgj_chat.models import rag
+
+
+def test_run_baseline_disables_retrieval(monkeypatch):
+    events = []
+
+    @contextmanager
+    def fake_mode():
+        events.append(("enter", rag._RETRIEVAL_DISABLED))
+        rag._RETRIEVAL_DISABLED = True
+        try:
+            yield
+        finally:
+            events.append(("exit", rag._RETRIEVAL_DISABLED))
+            rag._RETRIEVAL_DISABLED = False
+
+    monkeypatch.setattr(rag, "_baseline_mode", fake_mode)
+    monkeypatch.setattr(rag, "CHAT", lambda *a, **k: [{"generated_text": "resp"}])
+
+    result = rag.run_baseline("hello")
+
+    assert result == "resp"
+    assert events == [("enter", False), ("exit", True)]
+    assert rag._RETRIEVAL_DISABLED is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,3 +24,25 @@ def test_apply_cli_args():
     assert new_cfg.faiss_cuda is False
     # unchanged value
     assert new_cfg.index_path == cfg.index_path
+
+
+def test_cli_compare_flag(monkeypatch):
+    from vgj_chat import cli, config
+    from vgj_chat.ui import gradio_app
+
+    original = config.CFG
+
+    class Demo:
+        def queue(self):
+            return self
+
+        def launch(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(gradio_app, "build_demo", lambda: Demo())
+
+    try:
+        cli.main(["-c"])
+        assert cli.CFG.compare_mode is True
+    finally:
+        config.CFG = original

--- a/tests/test_gradio.py
+++ b/tests/test_gradio.py
@@ -14,3 +14,42 @@ def test_gradio_launch(monkeypatch):
         demo.launch(prevent_thread_lock=True)
         time.sleep(0.5)
         demo.close()
+
+
+def test_build_demo_compare_mode(monkeypatch):
+    from dataclasses import replace
+    from vgj_chat import config
+
+    monkeypatch.setattr(rag, "_ensure_boot", lambda: None)
+    monkeypatch.setattr(gradio_app, "_ensure_boot", lambda: None)
+
+    created: list[object] = []
+
+    class CountingComponent:
+        def __init__(self, *a, **k):
+            created.append(self)
+
+        def submit(self, *a, **k):
+            return self
+
+        def then(self, *a, **k):
+            return self
+
+    monkeypatch.setattr(gradio_app.gr, "Chatbot", CountingComponent)
+    monkeypatch.setattr(
+        gradio_app.gr,
+        "Row",
+        lambda *a, **k: gradio_app.gr.Blocks(),
+        raising=False,
+    )
+
+    original_cfg = config.CFG
+    new_cfg = replace(config.CFG, compare_mode=True)
+    config.CFG = gradio_app.CFG = new_cfg
+
+    try:
+        gradio_app.build_demo()
+    finally:
+        config.CFG = gradio_app.CFG = original_cfg
+
+    assert len(created) == 2


### PR DESCRIPTION
## Summary
- verify compare mode CLI flag sets global cfg
- ensure Gradio demo builds 2 chatbots in compare mode
- test baseline mode disables retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68817654f4808323965de08efca59844