### PR TITLE
Add compare mode log message

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 
 from vgj_chat.config import Config
 
@@ -26,7 +27,7 @@ def test_apply_cli_args():
     assert new_cfg.index_path == cfg.index_path
 
 
-def test_cli_compare_flag(monkeypatch):
+def test_cli_compare_flag(monkeypatch, caplog):
     from vgj_chat import cli, config
     from vgj_chat.ui import gradio_app
 
@@ -40,9 +41,13 @@ def test_cli_compare_flag(monkeypatch):
             pass
 
     monkeypatch.setattr(gradio_app, "build_demo", lambda: Demo())
+    caplog.set_level(logging.INFO)
 
     try:
         cli.main(["-c"])
         assert cli.CFG.compare_mode is True
+        assert (
+            "Compare mode enabled: launching dual-chat UI" in caplog.text
+        )
     finally:
         config.CFG = original

--- a/vgj_chat/cli.py
+++ b/vgj_chat/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 from dataclasses import replace
 
@@ -21,6 +22,8 @@ def main(argv: list[str] | None = None) -> None:
     global CFG
     CFG = CFG.apply_cli_args(args)
     CFG = replace(CFG, compare_mode=args.compare)
+    if CFG.compare_mode:
+        logging.info("Compare mode enabled: launching dual-chat UI")
 
     from .ui.gradio_app import build_demo
 


### PR DESCRIPTION
## Summary
- log when compare mode is enabled
- test that the log message is emitted when running CLI with `-c`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881965b490c8323a027ae62c3f754d5