### PR TITLE
Default pipeline unlimited crawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ __main__.py       Enables `python -m vgj_chat`
 Run the helper scripts in order or execute the pipeline in one go:
 
 ```bash
-python scripts/run_pipeline.py --limit 20
+python scripts/run_pipeline.py
 ```
 
 Manual steps if you prefer running them individually:
@@ -111,7 +111,7 @@ Execute the helper scripts inside the running container to crawl pages, create
 an index and fine‑tune the adapter:
 
 ```bash
-docker exec -it <container> python scripts/run_pipeline.py --limit 20
+docker exec -it <container> python scripts/run_pipeline.py
 ```
 
 ### GPU compatibility issues

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,7 +1,6 @@
 import argparse
 import subprocess
 
-
 STEPS = [
     ["python", "scripts/crawl.py"],
     ["python", "scripts/build_index.py"],
@@ -16,13 +15,14 @@ def main() -> None:
     parser.add_argument(
         "--limit",
         type=int,
-        default=20,
+        default=None,
         help="Limit number of pages to crawl",
     )
     args = parser.parse_args()
 
     steps = STEPS.copy()
-    steps[0] = ["python", "scripts/crawl.py", "--limit", str(args.limit)]
+    if args.limit is not None:
+        steps[0] = ["python", "scripts/crawl.py", "--limit", str(args.limit)]
 
     for cmd in steps:
         subprocess.run(cmd, check=True)
@@ -30,4 +30,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
-


### PR DESCRIPTION
## Summary
- make pipeline crawling unlimited by default
- update README instructions

## Testing
- `ruff check .`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6881e1eccf488323b26f53d4e7274fca