### PR TITLE
Add views disclaimer to prompts

### DIFF
--- a/gradio_vgj_chat.py
+++ b/gradio_vgj_chat.py
@@ -242,6 +242,9 @@ def _answer_stream(history: list[dict[str, str]]):
     prompt = (
         "Answer the *single* question below using only the listed sources. "
         "Do not add additional questions, FAQs, or headings. "
+        "Begin your answer with 'This portfolio project was created by Daniel Short. "
+        "Views expressed do not represent Visit Grand Junction or the City of Grand Junction.' "
+        "Limit your answer to one or two short paragraphs. "
         "Cite each fact like [1].\n\n"
         f"{src_block}\n\nQ: {user_q}\nA:"
     )

--- a/vgj_chat/models/rag.py
+++ b/vgj_chat/models/rag.py
@@ -265,6 +265,9 @@ def answer_stream(
     prompt = (
         "Answer the *single* question below using only the listed sources. "
         "Do not add additional questions, FAQs, or headings. "
+        "Begin your answer with 'This portfolio project was created by Daniel Short. "
+        "Views expressed do not represent Visit Grand Junction or the City of Grand Junction.' "
+        "Limit your answer to one or two short paragraphs. "
         "Cite each fact like [1].\n\n"
         f"{src_block}\n\nQ: {user_q}\nA:"
     )
@@ -318,6 +321,9 @@ def chat(question: str) -> str:
         prompt = (
             "Answer the *single* question below using only the listed sources. "
             "Do not add additional questions, FAQs, or headings. "
+            "Begin your answer with 'This portfolio project was created by Daniel Short. "
+            "Views expressed do not represent Visit Grand Junction or the City of Grand Junction.' "
+            "Limit your answer to one or two short paragraphs. "
             "Cite each fact like [1].\n\n"
             f"{src_block}\n\nQ: {question}\nA:"
         )


### PR DESCRIPTION
## Summary
- clarify that responses reflect Daniel Short's portfolio project only
- instruct the model to limit answers to one or two short paragraphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c014f18708323a695e62bea8a0002