### PR TITLE
Add merged_model_dir default

### DIFF
--- a/gradio_vgj_chat.py
+++ b/gradio_vgj_chat.py
@@ -39,6 +39,7 @@ class Config:
     index_path: Path = Path("faiss.index")
     meta_path: Path = Path("meta.jsonl")
     lora_dir: Path = Path("lora-vgj-checkpoint")
+    merged_model_dir: Path = Path("mistral-merged-4bit")
 
     # models
     base_model: str = "mistralai/Mistral-7B-Instruct-v0.2"


### PR DESCRIPTION
## Summary
- expose `merged_model_dir` in `gradio_vgj_chat.py` config

## Testing
- `python -m py_compile gradio_vgj_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1999dac0832389fd8a9c22742e77