### PR TITLE
add sagemaker inference script

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,34 @@
+import json
+import os
+from typing import Any, Tuple
+
+
+def model_fn(model_dir: str) -> Any:
+    """Load model artifacts from ``model_dir`` and prepare for inference."""
+    os.environ.setdefault(
+        "VGJ_MERGED_MODEL_DIR", os.path.join(model_dir, "mistral-merged-4bit")
+    )
+    os.environ.setdefault("VGJ_INDEX_PATH", os.path.join(model_dir, "faiss.index"))
+    os.environ.setdefault("VGJ_META_PATH", os.path.join(model_dir, "meta.jsonl"))
+    from vgj_chat.models import rag
+
+    return rag
+
+
+def input_fn(request_body: bytes, request_content_type: str) -> str:
+    if request_content_type == "application/json":
+        data = json.loads(request_body)
+        return data.get("question") or data.get("inputs") or ""
+    if request_content_type == "text/plain":
+        return request_body.decode("utf-8")
+    raise ValueError(f"Unsupported content type: {request_content_type}")
+
+
+def predict_fn(input_data: str, model: Any) -> str:
+    return model.chat(input_data)
+
+
+def output_fn(prediction: str, accept: str) -> Tuple[str, str]:
+    if accept == "application/json":
+        return json.dumps({"answer": prediction}), accept
+    return prediction, "text/plain"

--- a/tests/test_wheel_imports.py
+++ b/tests/test_wheel_imports.py
@@ -1,8 +1,7 @@
 import importlib
 import subprocess
 import sys
-from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 
 
 def test_modules_import_from_wheel(tmp_path):
@@ -42,30 +41,35 @@ def test_modules_import_from_wheel(tmp_path):
     sys.modules.setdefault("trl", trl_mod)
 
     wheel_dir = tmp_path / "wheel"
-    subprocess.run([
-        sys.executable,
-        "-m",
-        "build",
-        "--wheel",
-        "--outdir",
-        str(wheel_dir),
-    ], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--outdir",
+            str(wheel_dir),
+        ],
+        check=True,
+    )
     wheel = next(wheel_dir.glob("vgj_chat-*.whl"))
     install_dir = tmp_path / "install"
-    subprocess.run([
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--no-deps",
-        "--target",
-        str(install_dir),
-        str(wheel),
-    ], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--target",
+            str(install_dir),
+            str(wheel),
+        ],
+        check=True,
+    )
     sys.path.insert(0, str(install_dir))
     try:
         importlib.import_module("vgj_chat.models.rag")
         importlib.import_module("vgj_chat.models.finetune")
     finally:
         sys.path.remove(str(install_dir))
-


### PR DESCRIPTION
## Summary
- add `inference.py` entrypoint for SageMaker PyTorch serving image
- clean up unused imports in wheel-build test

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e23b34c908323af885b4ecb52c987