### PR TITLE
Add FastAPI service and SageMaker deployment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,16 @@
-FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-devel
+################  Base image without TorchServe  ###############
+FROM pytorch/pytorch:2.2.2-cuda12.1-cudnn-devel
 
+################  Install Python deps  #########################
+COPY requirements.sagemaker.txt /tmp/req.txt
+RUN pip install --no-cache-dir -r /tmp/req.txt && rm /tmp/req.txt
 
+################  Copy code and model  #########################
+COPY model/ /opt/ml/model/
+COPY . /app
 WORKDIR /app
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git build-essential && \
-    rm -rf /var/lib/apt/lists/*
-
-# ----- dependency layer -----
-# includes bitsandbytes for 4-bit quantisation
-COPY requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
-
-# ----- source code -----
-COPY . .
 RUN pip install --no-cache-dir .
 
-
-EXPOSE 7860
-CMD ["python", "-m", "vgj_chat"]
+################  Expose port & launch  ########################
+EXPOSE 8080
+CMD ["python", "serve.py"]

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,1 @@
+Place model artifacts (model.safetensors, config.json, tokenizer.json, faiss.index, meta.jsonl, etc.) here.

--- a/model/meta.jsonl
+++ b/model/meta.jsonl
@@ -1,0 +1,1 @@
+{"text": "Sample context"}

--- a/requirements.sagemaker.txt
+++ b/requirements.sagemaker.txt
@@ -1,8 +1,7 @@
-numpy<2
-faiss-cpu==1.8.0
-bitsandbytes==0.45.5
-accelerate==1.6.0
-git+https://github.com/huggingface/transformers.git@v4.51.0
-trl
-peft
-
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+transformers==4.42.1
+accelerate==0.30.1
+sentencepiece
+faiss-cpu
+bitsandbytes


### PR DESCRIPTION
## Summary
- add `serve.py` FastAPI app with `/ping` and `/invocations` routes for model serving
- define SageMaker requirements list for FastAPI, transformers, and related libs
- replace Dockerfile to build container with model artifacts and launch service
- add `model/` directory placeholder for model and retrieval files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f707de2e88323b24bd062f4f2a165