### PR TITLE
chore: slim docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 archive
+model/
 tests
 __pycache__
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ FROM pytorch/pytorch:2.2.2-cuda12.1-cudnn8-devel
 COPY requirements.sagemaker.txt /tmp/req.txt
 RUN pip install --no-cache-dir -r /tmp/req.txt && rm /tmp/req.txt
 
-################  Copy code and model  #########################
-COPY model/ /opt/ml/model/
-COPY . /app
+################  Copy application code  ########################
 WORKDIR /app
+COPY serve.py .
+COPY inference.py .
+COPY gradio_vgj_chat.py .
+COPY pyproject.toml .
+COPY README.md .
+COPY vgj_chat ./vgj_chat
 RUN pip install --no-cache-dir .
 
 ################  Expose port & launch  ########################


### PR DESCRIPTION
## Summary
- ignore `model/` in `.dockerignore` to shrink Docker build context
- copy only required source files in Dockerfile instead of entire repository

## Testing
- `pre-commit run --files .dockerignore Dockerfile` (fails: InvalidManifestError)
- `docker build -t vgj-chat .` (fails: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_e_688f87a868908323b77de609798d66bc