### PR TITLE
Specify label names for SFTTrainer

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import os
 
 import torch
 from datasets import load_dataset
+from huggingface_hub import login
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 from sklearn.model_selection import train_test_split
 from transformers import (
@@ -17,7 +17,6 @@ from transformers import (
     TrainingArguments,
 )
 from trl import SFTTrainer
-from huggingface_hub import login
 
 BASE_MODEL = "mistralai/Mistral-7B-Instruct-v0.2"
 # dataset built by ``vgj_chat.data.dataset.build_auto_dataset``
@@ -115,6 +114,7 @@ def run_finetune() -> None:
                 early_stopping_patience=PATIENCE, early_stopping_threshold=0.0
             )
         ],
+        label_names=[],
     )
     trainer.train()
     model.save_pretrained(CHECKPOINT_DIR)


### PR DESCRIPTION
## Summary
- add explicit `label_names` parameter to `SFTTrainer` so label handling is clear
- tidy imports after linting

## Testing
- `isort --check-only --profile=black -v vgj_chat/models/finetune.py`
- `black vgj_chat/models/finetune.py --check`
- `ruff check vgj_chat/models/finetune.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fca2518dc83238b0491564c7ed146