### PR TITLE
Disable cache for PEFT model

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -72,6 +72,7 @@ def run_finetune() -> None:
         task_type="CAUSAL_LM",
     )
     model = get_peft_model(base, lora_cfg)
+    model.config.use_cache = False
 
     def to_chat(ex):
         user = ex["instruction"].strip()


### PR DESCRIPTION
## Summary
- Turn off cache in PEFT model config before training

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fca27d8708323bdfa92030417bbae