### PR TITLE
Enable gradient checkpointing

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -72,6 +72,10 @@ def run_finetune() -> None:
         task_type="CAUSAL_LM",
     )
     model = get_peft_model(base, lora_cfg)
+    model.config.use_cache = False
+    model.gradient_checkpointing_enable(
+        gradient_checkpointing_kwargs={"use_reentrant": False}
+    )
 
     def to_chat(ex):
         user = ex["instruction"].strip()


### PR DESCRIPTION
## Summary
- disable model cache before training
- explicitly enable gradient checkpointing with use_reentrant=False for compatibility with future PyTorch releases

## Testing
- `pip install build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fca28e1f883238ac34bc957ccc0f8