### PR TITLE
Archive merged model directory

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -50,8 +50,7 @@ def main() -> None:
     archive = Path("mistral-rag.tar.gz")
     with tarfile.open(archive, "w:gz") as tar:
         if merged_src.exists():
-            for item in merged_src.iterdir():
-                tar.add(item, arcname=item.name)
+            tar.add(merged_src, arcname=merged_src.name)
         tar.add("faiss.index", arcname="faiss.index")
         tar.add("meta.jsonl", arcname="meta.jsonl")
     print(f"Created {archive}")


### PR DESCRIPTION
## Summary
- archive the entire `mistral-merged-4bit` directory in `mistral-rag.tar.gz` to preserve its structure

## Testing
- `pytest -q`
- manual tar creation confirmed `mistral-merged-4bit/` and its contents are stored in the archive


------
https://chatgpt.com/codex/tasks/task_e_688fd0f63c488323bdf14fcad5aa7369