### PR TITLE
check merged model dir before loading

### DIFF
--- a/tests/test_missing_model_dir.py
+++ b/tests/test_missing_model_dir.py
@@ -1,0 +1,18 @@
+from dataclasses import replace
+
+import pytest
+from vgj_chat.models import rag
+
+
+def test_boot_raises_when_model_dir_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(rag, "load_index", lambda *_: None)
+    monkeypatch.setattr(rag, "load_metadata", lambda *_: ([], []))
+    monkeypatch.setattr(rag, "SentenceTransformer", lambda *_, **__: None)
+    monkeypatch.setattr(rag, "CrossEncoder", lambda *_, **__: None)
+    monkeypatch.setattr(rag.torch, "float16", object(), raising=False)
+    monkeypatch.setattr(rag, "BitsAndBytesConfig", lambda *_, **__: None)
+    missing = tmp_path / "missing"
+    monkeypatch.setattr(rag, "CFG", replace(rag.CFG, merged_model_dir=missing))
+    with pytest.raises(FileNotFoundError) as exc:
+        rag._boot()
+    assert str(missing) in str(exc.value)

--- a/vgj_chat/models/rag.py
+++ b/vgj_chat/models/rag.py
@@ -82,6 +82,10 @@ def _boot() -> tuple[
         bnb_4bit_compute_dtype=torch.float16,
         bnb_4bit_use_double_quant=True,
     )
+    if not CFG.merged_model_dir.exists():
+        raise FileNotFoundError(
+            f"Expected merged model directory at {CFG.merged_model_dir}"
+        )
     tokenizer = AutoTokenizer.from_pretrained(str(CFG.merged_model_dir), use_fast=True)
     merged = AutoModelForCausalLM.from_pretrained(
         str(CFG.merged_model_dir),


### PR DESCRIPTION
## Summary
- ensure rag model boot fails early if merged model directory is missing
- add regression test for missing merged model directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd0f72aa88323a8173d7dd67d4f11