### PR TITLE
fix: remove label_names from SFTTrainer

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -118,7 +118,6 @@ def run_finetune() -> None:
                 early_stopping_patience=PATIENCE, early_stopping_threshold=0.0
             )
         ],
-        label_names=[],
     )
     trainer.train()
     model.save_pretrained(CHECKPOINT_DIR)


### PR DESCRIPTION
## Summary
- remove deprecated `label_names` argument from SFTTrainer in LoRA fine-tuning helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fefc57af88323a5be4fae81ddc95b