### PR TITLE
fix: remove label_names from SFTTrainer

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -105,8 +105,9 @@ def run_finetune() -> None:
         metric_for_best_model="eval_loss",
         greater_is_better=False,
         save_strategy="steps",
-        fp16=True,
+        fp16=torch.cuda.is_available(),
         report_to=[],
+        label_names=["labels"],
     )
     trainer = SFTTrainer(
         model=model,
@@ -118,7 +119,6 @@ def run_finetune() -> None:
                 early_stopping_patience=PATIENCE, early_stopping_threshold=0.0
             )
         ],
-        label_names=[],
     )
     trainer.train()
     model.save_pretrained(CHECKPOINT_DIR)


### PR DESCRIPTION
## Summary
- remove deprecated `label_names` argument from SFTTrainer in LoRA fine-tuning helper
- set label names via `TrainingArguments` and enable `fp16` only when CUDA is present to avoid runtime errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fefc57af88323a5be4fae81ddc95b