### PR TITLE
fix early stopping in lora finetune

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -29,8 +29,9 @@ LORA_ALPHA = 32
 LORA_DROPOUT = 0.05
 BATCH_PER_GPU = 4
 GRAD_ACC_STEPS = 4
-LOG_STEPS = 1
-EVAL_STEPS = 1
+LOG_STEPS = 10
+# evaluate and save once per epoch to avoid early stopping after only a few
+# optimisation steps
 PATIENCE = 3
 EPOCHS = 10
 LR = 2e-4
@@ -104,12 +105,11 @@ def run_finetune() -> None:
         lr_scheduler_type="cosine",
         warmup_ratio=0.03,
         logging_steps=LOG_STEPS,
-        eval_strategy="steps",
-        eval_steps=EVAL_STEPS,
+        eval_strategy="epoch",
+        save_strategy="epoch",
         load_best_model_at_end=True,
         metric_for_best_model="eval_loss",
         greater_is_better=False,
-        save_strategy="steps",
         fp16=False,
         bf16=bf16,
         report_to=[],


### PR DESCRIPTION
## Summary
- evaluate and save once per epoch so early stopping runs after full epochs
- use `eval_strategy` to match installed transformers API

## Testing
- `pre-commit run --files vgj_chat/models/finetune.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoy2y0w601/.pre-commit-hooks.yaml is not a file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68900310f234832398358bdadc83f6d1