### PR TITLE
feat: relocate dataset and simplify schema

### DIFF
--- a/vgj_chat/data/dataset.py
+++ b/vgj_chat/data/dataset.py
@@ -20,7 +20,8 @@ ANSWER_TOK_CAP = 220
 TXT_DIR = Path("data/html_txt")
 RAW_HTML_DIR = Path("data/raw_html")
 
-AUTO_QA_JL = Path("vgj_auto_dataset.jsonl")
+# store auto-generated pairs under data/dataset/
+AUTO_QA_JL = Path("data/dataset/vgj_auto_dataset.jsonl")
 MODEL_CACHE = Path("data/model_cache")
 
 # authenticate for gated base model if token available
@@ -99,9 +100,7 @@ def build_auto_dataset() -> None:
         if BOILER_PAT.search(answer):
             skipped += 1
             continue
-        auto_examples.append(
-            {"instruction": question, "input": passage, "output": answer}
-        )
+        auto_examples.append({"input": question, "output": answer})
     with AUTO_QA_JL.open("w") as f:
         for ex in auto_examples:
             f.write(json.dumps(ex) + "\n")

--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -22,7 +22,7 @@ from trl import SFTTrainer
 BASE_MODEL = "mistralai/Mistral-7B-Instruct-v0.2"
 # dataset built by ``vgj_chat.data.dataset.build_auto_dataset``
 # automatically generated Q&A pairs
-AUTO_QA_JL = Path("vgj_auto_dataset.jsonl")
+AUTO_QA_JL = Path("data/dataset/vgj_auto_dataset.jsonl")
 CHECKPOINT_DIR = Path("data/lora-vgj-checkpoint")
 MODEL_CACHE = Path("data/model_cache")
 
@@ -83,13 +83,12 @@ def run_finetune() -> None:
     model = get_peft_model(base, lora_cfg)
 
     def to_chat(ex):
-        user = ex["instruction"].strip()
-        if ex["input"]:
-            user += "\n" + ex["input"].strip()
-        return {"text": f"<s>[INST] {user} [/INST] {ex['output'].strip()} </s>"}
+        return {
+            "text": f"<s>[INST] {ex['input'].strip()} [/INST] {ex['output'].strip()} </s>"
+        }
 
     dataset = load_dataset("json", data_files=str(AUTO_QA_JL), split="train").map(
-        to_chat, remove_columns=["instruction", "input", "output"]
+        to_chat, remove_columns=["input", "output"]
     )
     train_idx, eval_idx = train_test_split(
         list(range(len(dataset))), test_size=0.1, random_state=42


### PR DESCRIPTION
## Summary
- save auto-generated QA pairs under `data/dataset/`
- drop `instruction` field so dataset contains only `input` and `output`
- update fine-tune helper to use new dataset path and schema

## Testing
- `pre-commit run --files vgj_chat/data/dataset.py vgj_chat/models/finetune.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68904c8acf14832388a5a3bb1b62fbb1