### PR TITLE
fix optimizer config for lora training

### DIFF
--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -110,7 +110,8 @@ def run_finetune() -> None:
         metric_for_best_model="eval_loss",
         greater_is_better=False,
         save_strategy="steps",
-        fp16=True,
+        fp16=torch.cuda.is_available(),
+        optim="paged_adamw_8bit" if torch.cuda.is_available() else "adamw_torch",
         report_to=[],
     )
     trainer = SFTTrainer(


### PR DESCRIPTION
## Summary
- use paged_adamw_8bit optimizer when training LoRA adapters
- enable fp16 only when CUDA is available

## Testing
- `pre-commit run --files vgj_chat/models/finetune.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890541ccb44832390532af317761c94