### PR TITLE
Handle label names and gradient checkpointing warnings

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -238,7 +238,9 @@ def main() -> None:
     if max_pos and max_pos > 0:
         tokenizer.model_max_length = min(tokenizer.model_max_length, max_pos)
 
-    base = prepare_model_for_kbit_training(base)
+    base = prepare_model_for_kbit_training(
+        base, gradient_checkpointing_kwargs={"use_reentrant": False}
+    )
     lora_cfg = LoraConfig(
         r=args.lora_r,
         lora_alpha=args.lora_alpha,
@@ -292,6 +294,7 @@ def main() -> None:
         train_dataset=datasets["train"],
         eval_dataset=datasets["test"],
         data_collator=data_collator,
+        label_names=["labels"],
         callbacks=[
             DiagnosticsCallback(model),
             EarlyStoppingCallback(early_stopping_patience=args.patience),


### PR DESCRIPTION
## Summary
- fix Trainer warning by setting `label_names=['labels']`
- avoid torch reentrant checkpoint warning by configuring `use_reentrant=False`

## Testing
- `pre-commit run --files scripts/finetune.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912e0e2fc88323be608680e735c6e5