### PR TITLE
Add sagemaker inference requirement

### DIFF
--- a/requirements.sagemaker.txt
+++ b/requirements.sagemaker.txt
@@ -6,3 +6,4 @@ sentencepiece
 faiss-cpu
 bitsandbytes
 sentence-transformers
+sagemaker-inference


### PR DESCRIPTION
## Summary
- add `sagemaker-inference` to SageMaker requirements list

## Testing
- `pre-commit run --files requirements.sagemaker.txt`
- `pytest`
- `docker build -f Dockerfile.sagemaker -t test-sagemaker .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68921e8d4ca0832389fa4677af529437