### PR TITLE
Add sentence window retrieval

### DIFF
--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -14,6 +14,8 @@ class DummyVector(list):
 
 class DummyEmbedder:
     def encode(self, query, normalize_embeddings=True):
+        if isinstance(query, list):
+            return [DummyVector([0.0, 0.0, 0.0]) for _ in query]
         return DummyVector([0.0, 0.0, 0.0])
 
 
@@ -29,7 +31,12 @@ class DummyReranker:
 
 def setup_module(module):
     rag.INDEX = DummyIndex()
-    rag.TEXTS = ["t1", "t2", "t3", "t4"]
+    rag.TEXTS = [
+        "t1 a. t1 b. t1 c. t1 d.",
+        "t2 a. t2 b. t2 c. t2 d.",
+        "t3 a. t3 b. t3 c. t3 d.",
+        "t4 a. t4 b. t4 c. t4 d.",
+    ]
     rag.URLS = ["u1", "u1", "u2", "u3"]
     rag.EMBEDDER = DummyEmbedder()
     rag.RERANKER = DummyReranker()
@@ -51,3 +58,13 @@ def test_retrieve_unique_shape():
         assert isinstance(text, str)
         assert isinstance(url, str)
     assert results[0][0] >= results[1][0]
+
+
+def test_retrieve_windows_shape():
+    results = rag.retrieve_windows("q")
+    assert isinstance(results, list)
+    assert len(results) <= 3
+    for block in results:
+        assert block.startswith("<DOC_ID:")
+        assert "<URL:" in block
+        assert "<DATE:" in block

--- a/vgj_chat/models/rag/__init__.py
+++ b/vgj_chat/models/rag/__init__.py
@@ -6,7 +6,7 @@ import types
 from . import baseline as _baseline
 from . import boot as _boot_mod
 from .generation import answer_stream, chat, run_enhanced
-from .retrieval import retrieve_unique
+from .retrieval import SentenceWindowRetriever, retrieve_unique, retrieve_windows
 
 _baseline_mode = _baseline._baseline_mode
 
@@ -41,6 +41,8 @@ sys.modules[__name__].__class__ = _RagModule  # type: ignore[misc]
 
 __all__ = [
     "retrieve_unique",
+    "retrieve_windows",
+    "SentenceWindowRetriever",
     "answer_stream",
     "chat",
     "run_enhanced",

--- a/vgj_chat/models/rag/retrieval.py
+++ b/vgj_chat/models/rag/retrieval.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from typing import List, Tuple
+
+import numpy as np
 
 from . import boot as _boot
 from .boot import logger
+
+DOC_TOP_K = 50
+WIN_TOP_K = 3
+MMR_LAMBDA = 0.3
 
 
 def retrieve_unique(query: str) -> List[Tuple[float, str, str]]:
@@ -42,4 +50,128 @@ def retrieve_unique(query: str) -> List[Tuple[float, str, str]]:
     return uniques
 
 
-__all__ = ["retrieve_unique"]
+@dataclass
+class _Window:
+    doc_id: int
+    para_id: int
+    url: str
+    date: str
+    text: str
+
+
+class SentenceWindowRetriever:
+    """Two‑stage retriever operating on 3‑sentence windows."""
+
+    def __init__(
+        self,
+        doc_top_k: int = DOC_TOP_K,
+        win_top_k: int = WIN_TOP_K,
+        mmr_lambda: float = MMR_LAMBDA,
+    ) -> None:
+        self.doc_top_k = doc_top_k
+        self.win_top_k = win_top_k
+        self.mmr_lambda = mmr_lambda
+
+    _SENT_SPLIT_RX = re.compile(r"(?<=[.!?])\s+")
+
+    @classmethod
+    def _windows_from_doc(cls, text: str) -> List[Tuple[int, str]]:
+        windows: List[Tuple[int, str]] = []
+        paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+        for p_idx, para in enumerate(paragraphs):
+            sentences = [s.strip() for s in cls._SENT_SPLIT_RX.split(para) if s.strip()]
+            if not sentences:
+                continue
+            for i in range(len(sentences)):
+                win = sentences[i : i + 3]
+                if not win:
+                    continue
+                windows.append((p_idx, " ".join(win)))
+                if i + 3 >= len(sentences):
+                    break
+        return windows
+
+    def retrieve_windows(self, query: str) -> List[str]:
+        if _boot._RETRIEVAL_DISABLED:
+            return []
+        _boot._ensure_boot()
+        assert _boot.EMBEDDER and _boot.INDEX and _boot.TEXTS and _boot.URLS
+
+        logger.debug("🔍 Query: %s", query)
+        q_vec = _boot.EMBEDDER.encode(query, normalize_embeddings=True).astype(
+            "float32"
+        )[None, :]
+        _d, idx = _boot.INDEX.search(q_vec, self.doc_top_k)
+
+        windows: List[_Window] = []
+        for doc_id in idx[0]:
+            text = _boot.TEXTS[doc_id]
+            url = _boot.URLS[doc_id]
+            for para_id, win_text in self._windows_from_doc(text):
+                windows.append(_Window(doc_id, para_id, url, "unknown", win_text))
+
+        if not windows:
+            return []
+
+        win_texts = [w.text for w in windows]
+        win_vecs = _boot.EMBEDDER.encode(win_texts, normalize_embeddings=True)
+        q = q_vec[0]
+        sims = [float(np.dot(vec, q)) for vec in win_vecs]
+
+        selected: List[int] = []
+        used_paras: set[Tuple[int, int]] = set()
+        while len(selected) < self.win_top_k and len(selected) < len(windows):
+            if not selected:
+                order = sorted(range(len(sims)), key=lambda i: sims[i], reverse=True)
+                chosen = None
+                for i in order:
+                    key = (windows[i].doc_id, windows[i].para_id)
+                    if key not in used_paras:
+                        chosen = i
+                        break
+                if chosen is None:
+                    break
+            else:
+                mmr_scores: List[Tuple[float, int]] = []
+                for i in range(len(windows)):
+                    if i in selected:
+                        continue
+                    key = (windows[i].doc_id, windows[i].para_id)
+                    if key in used_paras:
+                        continue
+                    sim_to_selected = max(
+                        float(np.dot(win_vecs[i], win_vecs[j])) for j in selected
+                    )
+                    mmr = (
+                        self.mmr_lambda * sims[i]
+                        - (1 - self.mmr_lambda) * sim_to_selected
+                    )
+                    mmr_scores.append((mmr, i))
+                if not mmr_scores:
+                    break
+                chosen = max(mmr_scores, key=lambda x: x[0])[1]
+
+            selected.append(chosen)
+            used_paras.add((windows[chosen].doc_id, windows[chosen].para_id))
+
+        blocks = [
+            f"<DOC_ID:{windows[i].doc_id}> <URL:{windows[i].url}> <DATE:{windows[i].date}>\n{windows[i].text}"
+            for i in selected
+        ]
+        return blocks
+
+
+_DEFAULT_SENTENCE_WINDOW_RETRIEVER = SentenceWindowRetriever()
+
+
+def retrieve_windows(query: str) -> List[str]:
+    """Return top windows with metadata tags for *query*."""
+
+    return _DEFAULT_SENTENCE_WINDOW_RETRIEVER.retrieve_windows(query)
+
+
+__all__ = [
+    "retrieve_unique",
+    "SentenceWindowRetriever",
+    "retrieve_windows",
+]


### PR DESCRIPTION
## Summary
- extend retrieval module with `SentenceWindowRetriever` for two-stage document/window search using MMR and metadata tags
- expose new `retrieve_windows` API while keeping existing retrieval functions
- add regression tests for window retrieval

## Testing
- `pre-commit run --files vgj_chat/models/rag/retrieval.py vgj_chat/models/rag/__init__.py tests/test_retrieval.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893787797848323819e0d6e5a343496