### PR TITLE
Add deterministic retriever tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Sequence
+
+import numpy as np
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -10,12 +14,11 @@ if str(ROOT) not in sys.path:
 if "torch" not in sys.modules:
     torch_stub = ModuleType("torch")
     torch_stub.cuda = SimpleNamespace(is_available=lambda: False)
+    torch_stub.ones_like = lambda x: [1] * len(x)
     sys.modules["torch"] = torch_stub
-
-if "numpy" not in sys.modules:
-    numpy_stub = ModuleType("numpy")
-    numpy_stub.dot = lambda a, b: 0.0
-    sys.modules["numpy"] = numpy_stub
+else:  # pragma: no cover - ensure stub has ones_like
+    if not hasattr(sys.modules["torch"], "ones_like"):
+        sys.modules["torch"].ones_like = lambda x: [1] * len(x)
 
 for mod_name in ["faiss", "sentence_transformers", "transformers", "peft"]:
     if mod_name not in sys.modules:
@@ -34,3 +37,59 @@ sys.modules["transformers"].TextIteratorStreamer = object
 sys.modules["transformers"].pipeline = lambda *a, **k: None
 
 sys.modules["peft"].PeftModel = object
+
+
+# ------------------------------------------------------------------
+# Deterministic retrieval helpers
+# ------------------------------------------------------------------
+
+
+class FixedEmbedder:
+    """Simple keyword based embedder for tests."""
+
+    def encode(self, texts: Sequence[str] | str, normalize_embeddings: bool = True):
+        def _vec(txt: str) -> np.ndarray:
+            v = np.zeros(3, dtype="float32")
+            for i, token in enumerate(("alpha", "beta", "gamma")):
+                if token in txt.lower():
+                    v[i] = 1.0
+            return v
+
+        if isinstance(texts, list):
+            return [_vec(t) for t in texts]
+        return _vec(texts)
+
+
+class FakeIndex:
+    """FAISS-like index performing brute-force dot search."""
+
+    def __init__(self, texts: Sequence[str], embedder: FixedEmbedder):
+        self.vecs = [embedder.encode(t) for t in texts]
+
+    def search(self, q_vec, k: int):
+        sims = [float(np.dot(v, q_vec[0])) for v in self.vecs]
+        order = sorted(range(len(sims)), key=lambda i: sims[i], reverse=True)
+        return None, [order[:k]]
+
+
+@pytest.fixture
+def set_retrieval_env(monkeypatch):
+    """Configure :mod:`vgj_chat.models.rag.boot` with deterministic resources."""
+
+    from vgj_chat.models.rag import boot as _boot
+
+    def _set(texts: Sequence[str], urls: Sequence[str] | None = None):
+        if urls is None:
+            urls = [f"u{i}" for i in range(len(texts))]
+        embedder = FixedEmbedder()
+        index = FakeIndex(texts, embedder)
+        monkeypatch.setattr(_boot, "TEXTS", list(texts))
+        monkeypatch.setattr(_boot, "URLS", list(urls))
+        monkeypatch.setattr(_boot, "EMBEDDER", embedder)
+        monkeypatch.setattr(_boot, "INDEX", index)
+        monkeypatch.setattr(_boot, "_RETRIEVAL_DISABLED", False)
+        monkeypatch.setattr(_boot, "_ensure_boot", lambda: None)
+        monkeypatch.setattr(_boot, "_BOOTED", True)
+        return embedder, index
+
+    return _set

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+from scripts import run_pipeline
+from vgj_chat.models.rag.retrieval import SentenceWindowRetriever
+from vgj_chat.utils.text import token_len
+
+
+def test_windowize_stride_one():
+    text = "A. B. C. D."
+    windows = SentenceWindowRetriever._windows_from_doc(text)
+    assert windows == [(0, "A. B. C."), (0, "B. C. D.")]
+
+
+def test_two_stage_retrieval_respects_limits(set_retrieval_env):
+    texts = [
+        "alpha one. alpha two. alpha three. alpha four.",
+        "beta one. beta two. beta three. beta four.",
+        "alpha five. alpha six. alpha seven. alpha eight.",
+    ]
+    set_retrieval_env(texts)
+    retriever = SentenceWindowRetriever(doc_top_k=2, win_top_k=2)
+    blocks = retriever.retrieve_windows("alpha")
+    assert len(blocks) == 2
+    assert all("<DOC_ID:0>" in b or "<DOC_ID:2>" in b for b in blocks)
+
+
+def test_mmr_drops_redundant_windows(set_retrieval_env):
+    texts = ["alpha one. alpha two. alpha three. alpha four. alpha five."]
+    set_retrieval_env(texts)
+    retriever = SentenceWindowRetriever(doc_top_k=1, win_top_k=3, mmr_lambda=0.3)
+    blocks = retriever.retrieve_windows("alpha")
+    assert len(blocks) == 1
+
+
+def test_context_assembly_limits(monkeypatch):
+    blocks = [
+        "<DOC_ID:0> <PARA_ID:0> <URL:u0> <DATE:unknown>\na b",
+        "<DOC_ID:1> <PARA_ID:0> <URL:u1> <DATE:unknown>\nc d",
+        "<DOC_ID:2> <PARA_ID:0> <URL:u2> <DATE:unknown>\ne f",
+    ]
+    monkeypatch.setattr(
+        run_pipeline.SentenceWindowRetriever, "retrieve_windows", lambda self, q: blocks
+    )
+    monkeypatch.setattr(run_pipeline, "CTX_TOK_LIMIT", 10)
+    monkeypatch.setattr(run_pipeline, "OUT_TOK_LIMIT", 3)
+
+    from vgj_chat.models.rag import boot as _boot
+
+    monkeypatch.setattr(_boot, "_ensure_boot", lambda: None)
+
+    class DummyTokOut(dict):
+        def to(self, device):
+            return self
+
+    class DummyModel:
+        device = "cpu"
+
+        def generate(self, input_ids, attention_mask, max_new_tokens, do_sample):
+            self.max_new_tokens = max_new_tokens
+            return [list(range(len(input_ids) + max_new_tokens))]
+
+    class DummyTokenizer:
+        def __init__(self):
+            self.model = None
+
+        def __call__(self, prompt, return_tensors="pt"):
+            self.last_prompt = prompt
+            self.input_len = len(prompt.split())
+            return DummyTokOut({"input_ids": [0] * self.input_len})
+
+        def decode(self, tokens, skip_special_tokens=True):
+            return self.last_prompt + " " + "ans " * self.model.max_new_tokens
+
+    tok = DummyTokenizer()
+    model = DummyModel()
+    tok.model = model
+    chat = SimpleNamespace(tokenizer=tok, model=model)
+    monkeypatch.setattr(_boot, "CHAT", chat)
+    monkeypatch.setattr(_boot, "CFG", SimpleNamespace(max_new_tokens=10))
+
+    answer = run_pipeline._answer("q")
+    assert blocks[0] in tok.last_prompt
+    assert blocks[1] not in tok.last_prompt
+    assert token_len(answer) == 3


### PR DESCRIPTION
## Summary
- add deterministic FAISS and embedding stubs for tests
- cover windowising, retrieval limits, MMR de-duplication and context assembly

## Testing
- `pre-commit run --files tests/conftest.py tests/test_retriever.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893858e77888323b28fbd46984ea6cc