### PR TITLE
Refine context generation for finetuning dataset

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,93 @@
+import importlib
+import re
+import sys
+import types
+
+from types import ModuleType
+
+
+def _load_gen_context(monkeypatch, text: str):
+    """Reload dataset with heavy dependencies stubbed and return _gen_context."""
+
+    class _DummyNoGrad:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    torch_stub = types.SimpleNamespace(
+        no_grad=lambda: _DummyNoGrad(),
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+        float16="float16",
+        float32="float32",
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    monkeypatch.setitem(sys.modules, "trafilatura", ModuleType("trafilatura"))
+
+    dataset = importlib.reload(importlib.import_module("vgj_chat.data.dataset"))
+
+    class DummyTensor(list):
+        @property
+        def shape(self):
+            return (len(self),)
+
+    class DummyInput(dict):
+        def __init__(self):
+            super().__init__({"input_ids": DummyTensor([1, 2, 3])})
+            self.input_ids = self["input_ids"]
+
+        def to(self, device):
+            return self
+
+    class DummyTokenizer:
+        def __init__(self, text: str):
+            self.text = text
+            self.eos_token_id = 0
+
+        def __call__(self, prompt, return_tensors=None):
+            return DummyInput()
+
+        def decode(self, ids, skip_special_tokens=True):
+            return self.text
+
+    class DummyLLM:
+        device = "cpu"
+
+        def generate(self, **kwargs):
+            return [DummyTensor([0, 1, 2, 3, 4])]
+
+    tok = DummyTokenizer(text)
+    llm = DummyLLM()
+    return dataset._gen_context, tok, llm
+
+
+def test_gen_context_returns_complete_sentences(monkeypatch):
+    incomplete_text = (
+        "The first sentence is complete. "
+        "This is another complete sentence. "
+        "This final sentence is cut off"
+    )
+    _gen_context, tok, llm = _load_gen_context(monkeypatch, incomplete_text)
+
+    ctx = _gen_context("question", "answer", tok, llm)
+
+    assert ctx.endswith((".", "!", "?")), "Context should end with punctuation"
+    sentences = re.findall(r"[^.!?]+[.!?]", ctx)
+    assert 2 <= len(sentences) <= 3
+    reconstructed = " ".join(s.strip() for s in sentences)
+    assert ctx == reconstructed
+    assert "cut off" not in ctx
+
+
+def test_gen_context_single_sentence(monkeypatch):
+    single_sentence = "Only one complete sentence here."
+    _gen_context, tok, llm = _load_gen_context(monkeypatch, single_sentence)
+
+    ctx = _gen_context("question", "answer", tok, llm)
+
+    assert ctx.endswith((".", "!", "?"))
+    assert ctx == single_sentence
+    sentences = re.findall(r"[^.!?]+[.!?]", ctx)
+    assert len(sentences) == 1
+

--- a/vgj_chat/data/dataset.py
+++ b/vgj_chat/data/dataset.py
@@ -62,16 +62,21 @@ def _gen_context(
         f"ANSWER_SNIPPET: {answer_part}\n[/INST]"
     )
     ids = tok(prompt, return_tensors="pt").to(llm.device)
-    with torch.no_grad():
-        out = llm.generate(
-            **ids,
-            max_new_tokens=80,
-            pad_token_id=tok.eos_token_id,
-            do_sample=True,
-            temperature=0.7,
-            top_p=0.9,
-        )[0]
-    ctx = tok.decode(out[ids.input_ids.shape[-1] :], skip_special_tokens=True).strip()
+    for _ in range(3):
+        with torch.no_grad():
+            out = llm.generate(
+                **ids,
+                max_new_tokens=80,
+                pad_token_id=tok.eos_token_id,
+                do_sample=True,
+                temperature=0.7,
+                top_p=0.9,
+            )[0]
+        ctx = tok.decode(out[ids.input_ids.shape[-1] :], skip_special_tokens=True).strip()
+        sentences = re.findall(r"[^.!?]+[.!?]", ctx)
+        if len(sentences) >= 2:
+            keep = min(len(sentences), random.choice([2, 3]))
+            return " ".join(s.strip() for s in sentences[:keep])
     return ctx
 
 
@@ -144,9 +149,15 @@ def build_auto_dataset() -> None:
         ctx_blocks: list[str] = []
         if available_parts:
             max_ctx = min(len(available_parts), CTX_MAX)
-            num_ctx = random.randint(0, max_ctx)
-            if num_ctx:
-                for part in random.sample(available_parts, k=num_ctx):
+            if max_ctx:
+                if max_ctx < 2:
+                    num_ctx = max_ctx
+                else:
+                    num_ctx = round(random.gauss(3, 1))
+                    num_ctx = max(2, min(4, num_ctx))
+                    num_ctx = min(num_ctx, max_ctx)
+                ctx_parts = random.sample(available_parts, k=num_ctx)
+                for part in ctx_parts:
                     ctx_blocks.append(
                         f"<CONTEXT>\n{_gen_context(question, part, tok, llm)}\n</CONTEXT>"
                     )


### PR DESCRIPTION
## Summary
- Ensure generated context passages consist of full 2-3 sentence blocks
- Sample 2-4 context snippets per question using a normal distribution centered on three
- Add regression tests verifying `_gen_context` only returns complete sentences, including single-sentence fallback behavior

## Testing
- `pip install build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c8a2c40483239e01380977e2dac3