### PR TITLE
Handle missing text in metadata

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -50,9 +50,13 @@ def predict_fn(data, ctx):
             f"Embedding dimension {emb_query.shape[0]} does not match index dimension {mdl['index'].d}"
         )
     _distances, indices = mdl["index"].search(emb_query.reshape(1, -1), top_k)
-    retrieved = "\n".join(
-        f"<CONTEXT>{mdl['meta'][idx]['text']}</CONTEXT>" for idx in indices[0]
-    )
+    retrieved_parts = []
+    for idx in indices[0]:
+        meta = mdl["meta"][idx]
+        text = meta.get("text")
+        if text:
+            retrieved_parts.append(f"<CONTEXT>{text}</CONTEXT>")
+    retrieved = "\n".join(retrieved_parts)
 
     messages = [
         {

--- a/serve.py
+++ b/serve.py
@@ -51,7 +51,9 @@ def invoke(p: Prompt):
     sources: list[str] = []
     for h in hits:
         src = h.get("source") or h.get("url") or "unknown"
-        context_parts.append(f"<CONTEXT>{src}: {h['text']}</CONTEXT>")
+        text = h.get("text")
+        if text:
+            context_parts.append(f"<CONTEXT>{src}: {text}</CONTEXT>")
         if src not in sources:
             sources.append(src)
     context = "\n".join(context_parts)


### PR DESCRIPTION
## Summary
- Avoid KeyError when metadata entries lack text in the HTTP server
- Skip metadata records without text when building inference context

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689423516e408323b28d6d637f69a7be