### PR TITLE
Ensure RAG uses contextual sources and focuses on Grand Junction

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -67,7 +67,12 @@ def invoke(p: Prompt):
     messages = [
         {
             "role": "system",
-            "content": "You are a friendly travel expert representing Visit Grand Junction.",
+            "content": (
+                "You are a friendly travel expert representing Visit Grand Junction. "
+                "Only discuss attractions in Grand Junction, Colorado. "
+                "If asked about other destinations, prices, or deals, politely state that you can only "
+                "talk about Grand Junction. Limit your response to one or two short paragraphs."
+            ),
         },
         {"role": "user", "content": f"{context}\n\n{p.inputs}"},
     ]
@@ -83,6 +88,8 @@ def invoke(p: Prompt):
         input_ids=input_ids,
         max_new_tokens=CFG.max_new_tokens,
         temperature=0.2,  # keeps it concise
+        eos_token_id=TOKENIZER.eos_token_id,
+        pad_token_id=TOKENIZER.eos_token_id,
     )
 
     # --- token accounting --------------------------------------------------
@@ -102,8 +109,13 @@ def invoke(p: Prompt):
         output[0][n_prompt:], skip_special_tokens=True
     ).strip()
 
+    src_text = ", ".join(sources)
+    generated = DISCLAIMER + answer_text
+    if src_text:
+        generated += f"\n\nSources: {src_text}"
+
     return {
-        "generated_text": DISCLAIMER + answer_text,
+        "generated_text": generated,
         "sources": sources,
         "token_usage": {
             "prompt": n_prompt,

--- a/vgj_chat/data/index.py
+++ b/vgj_chat/data/index.py
@@ -65,12 +65,20 @@ def build_index(
             normalize_embeddings=True,
             show_progress_bar=False,
         )
-        for window_idx, vec in enumerate(vecs):
+        for window_idx, (win_text, vec) in enumerate(zip(windows, vecs)):
             if index is None:
                 index = faiss.IndexFlatIP(vec.shape[0])
             index.add(vec.reshape(1, -1))
             meta_f.write(
-                json.dumps({"doc_id": doc_id, "window_idx": window_idx}) + "\n"
+                json.dumps(
+                    {
+                        "doc_id": doc_id,
+                        "window_idx": window_idx,
+                        "text": win_text,
+                        "url": url,
+                    }
+                )
+                + "\n"
             )
         doc_id += 1
         if max_docs is not None and doc_id >= max_docs:

--- a/vgj_chat/models/rag/generation.py
+++ b/vgj_chat/models/rag/generation.py
@@ -8,10 +8,13 @@ from . import boot as _boot
 from .boot import logger
 from .retrieval import retrieve_unique
 
-system_prompt = """You are a friendly travel expert representing Visit Grand Junction. 
-Use the supplied context excerpts to answer questions about Grand Junction, Colorado and its surroundings in a warm, adventurous tone that highlights outdoor recreation, local culture, and natural beauty. 
-Cite or reference the context when relevant. 
+system_prompt = (
+    """You are a friendly travel expert representing Visit Grand Junction.
+Use the supplied context excerpts to answer questions about Grand Junction, Colorado and its surroundings in a warm, adventurous tone that highlights outdoor recreation, local culture, and natural beauty.
+Only discuss Grand Junction, Colorado. If asked about other destinations, prices, or deals, politely explain that you can only talk about Grand Junction.
+Cite or reference the context when relevant.
 If the context does not contain the needed information, say you don’t know and recommend checking official Visit Grand Junction resources."""
+)
 
 # ───────────────────────────────────
 # 🔧 helper: build the shared prompt


### PR DESCRIPTION
## Summary
- embed FAISS metadata with text and URLs so retrieved passages carry their sources
- tighten system prompts to only discuss Grand Junction, avoid deals, and keep answers short
- surface citation URLs in responses and include token usage details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942fad11b08323905259653a4a0d53