### PR TITLE
feat: switch default model to gpt-oss 20b

### DIFF
--- a/Dockerfile.sagemaker
+++ b/Dockerfile.sagemaker
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir .
 
 ENV VGJ_INDEX_PATH=/opt/ml/model/faiss.index \
     VGJ_META_PATH=/opt/ml/model/meta.jsonl \
-    VGJ_MERGED_MODEL_DIR=/opt/ml/model/mistral-merged-4bit
+    VGJ_MERGED_MODEL_DIR=/opt/ml/model/gpt-oss-20b-merged-4bit
 
 EXPOSE 8080
 ENTRYPOINT ["python", "serve.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chatbot-LoRa-RAG
 
-A lightweight Retrieval-Augmented Generation (RAG) demo that fine‑tunes a language model with LoRA, merges the adapter into a 4‑bit Mistral‑7B model and exposes a FastAPI endpoint for inference. The code lives in the `vgj_chat` package and includes helper scripts for crawling pages, building an index and training or merging the adapter.
+A lightweight Retrieval-Augmented Generation (RAG) demo that fine‑tunes a language model with LoRA, merges the adapter into a 4‑bit gpt‑oss‑20B model and exposes a FastAPI endpoint for inference. The code lives in the `vgj_chat` package and includes helper scripts for crawling pages, building an index and training or merging the adapter.
 
 ## Installation
 

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -45,9 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--data", type=str, required=True, help="JSONL file with Q&A pairs"
     )
-    parser.add_argument(
-        "--model-name", type=str, default="mistralai/Mistral-7B-Instruct-v0.2"
-    )
+    parser.add_argument("--model-name", type=str, default="openai/gpt-oss-20b")
     parser.add_argument("--output-dir", type=str, default="data/lora-vgj-checkpoint")
     parser.add_argument("--prompt-field", type=str, default="input")
     parser.add_argument("--response-field", type=str, default="output")

--- a/scripts/merge_lora.py
+++ b/scripts/merge_lora.py
@@ -3,17 +3,13 @@ import os
 from pathlib import Path
 
 import torch
-from peft import PeftModel
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    BitsAndBytesConfig,
-)
 from huggingface_hub import login
+from peft import PeftModel
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 
-DEFAULT_BASE = "mistralai/Mistral-7B-Instruct-v0.2"
+DEFAULT_BASE = "openai/gpt-oss-20b"
 DEFAULT_LORA = "data/lora-vgj-checkpoint"
-DEFAULT_OUT = "data/mistral-merged-4bit"
+DEFAULT_OUT = "data/gpt-oss-20b-merged-4bit"
 MODEL_CACHE = Path("data/model_cache")
 
 # must match special tokens used during fine-tuning

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import torch  # type: ignore
 
-from vgj_chat.models.rag.retrieval import SentenceWindowRetriever
 from vgj_chat.models.rag import boot as _boot
+from vgj_chat.models.rag.retrieval import SentenceWindowRetriever
 from vgj_chat.utils.text import token_len
 
 CRAWL_TXT_DIR = Path("data/html_txt")
@@ -19,7 +19,7 @@ META_PATH = Path("data/meta.jsonl")
 
 # ──────────────────────────────────────────────────────────
 # NEW CONSTANTS
-MERGED_SRC = Path("data/mistral-merged-4bit")
+MERGED_SRC = Path("data/gpt-oss-20b-merged-4bit")
 DEST_DIR = Path("model")  # or Path("models") if you prefer
 ARCHIVE = Path("model.tar.gz")  # will live in project root
 # ──────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ def _answer(question: str) -> str:
         do_sample=False,
     )
 
-    return tok.decode(generated[0], skip_special_tokens=True)[len(prompt):].strip()
+    return tok.decode(generated[0], skip_special_tokens=True)[len(prompt) :].strip()
 
 
 def main() -> None:

--- a/vgj_chat/config.py
+++ b/vgj_chat/config.py
@@ -18,10 +18,10 @@ class Config:
     meta_path: Path = Path("data/meta.jsonl")
     lora_dir: Path = Path("data/lora-vgj-checkpoint")
     # directory containing the merged 4-bit model
-    merged_model_dir: Path = Path("data/mistral-merged-4bit")
+    merged_model_dir: Path = Path("data/gpt-oss-20b-merged-4bit")
 
     # models
-    base_model: str = "mistralai/Mistral-7B-Instruct-v0.2"
+    base_model: str = "openai/gpt-oss-20b"
     embed_model: str = "sentence-transformers/all-MiniLM-L6-v2"
     rerank_model: str = "BAAI/bge-reranker-base"
 

--- a/vgj_chat/models/finetune.py
+++ b/vgj_chat/models/finetune.py
@@ -1,12 +1,12 @@
 """LoRA/QLoRA fine‑tuning helper.
 
 This script follows the recommended recipe for adapting
-``mistralai/Mistral-7B-Instruct-v0.2`` into the Visit Grand Junction
-travel‑agent model.  It mirrors the steps described in the rough guide:
+``openai/gpt-oss-20b`` into the Visit Grand Junction travel‑agent model. It
+mirrors the steps described in the rough guide:
 
-* load the Mistral tokenizer without the fast backend and register
-  optional special tokens (``<CONTEXT>``, ``</CONTEXT>``) that can be used
-  when injecting retrieved chunks during RAG inference;
+* load the gpt‑oss tokenizer and register optional special tokens
+  (``<CONTEXT>``, ``</CONTEXT>``) that can be used when injecting retrieved
+  chunks during RAG inference;
 * quantise the base model to 4‑bit weights and apply a LoRA adapter to
   the major linear layers (``q_proj``, ``k_proj``, ``v_proj``, ``o_proj``,
   ``gate_proj``, ``up_proj`` and ``down_proj``) with rank 16 and zero
@@ -36,15 +36,17 @@ from transformers import (
 try:  # transformers is stubbed in tests
     from transformers import TrainerCallback
 except Exception:  # pragma: no cover – fallback for minimal stubs
+
     class TrainerCallback:  # type: ignore
         pass
 
-from trl import SFTTrainer, SFTConfig  # NEW import
+
+from trl import SFTConfig, SFTTrainer  # NEW import
 
 # --------------------------------------------------------------------------- #
 # Constants
 # --------------------------------------------------------------------------- #
-BASE_MODEL = "mistralai/Mistral-7B-Instruct-v0.2"
+BASE_MODEL = "openai/gpt-oss-20b"
 # dataset built by ``vgj_chat.data.dataset.build_auto_dataset`` – Q&A pairs
 AUTO_QA_JL = Path("data/dataset/vgj_auto_dataset.jsonl")
 CHECKPOINT_DIR = Path("data/lora-vgj-checkpoint")
@@ -231,7 +233,7 @@ def run_finetune() -> None:
     # ----------------------- SFT config (key fix) ------------------------- #
     sft_cfg = SFTConfig(
         completion_only_loss=False,  # disable so formatter is allowed
-        dataset_text_field=None,     # let trainer use formatter output
+        dataset_text_field=None,  # let trainer use formatter output
     )
 
     # ----------------------- trainer -------------------------------------- #
@@ -241,7 +243,7 @@ def run_finetune() -> None:
         train_dataset=train_set,
         eval_dataset=eval_set,
         formatting_func=format_example,
-        config=sft_cfg,              # NEW
+        config=sft_cfg,  # NEW
         callbacks=[
             EarlyStoppingCallback(
                 early_stopping_patience=PATIENCE, early_stopping_threshold=0.0


### PR DESCRIPTION
## Summary
- replace Mistral-7B defaults with OpenAI gpt-oss-20b
- point scripts and config to gpt-oss merged-model directory
- update docs and SageMaker Dockerfile for new model

## Testing
- `pre-commit run --files vgj_chat/config.py vgj_chat/models/finetune.py scripts/finetune.py scripts/merge_lora.py scripts/run_pipeline.py Dockerfile.sagemaker README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957565fabc832388149cba57553ca5