### PR TITLE
feat: drop incomplete ending paragraph

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -11,7 +11,7 @@ from sentence_transformers import SentenceTransformer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from vgj_chat.config import CFG
-from vgj_chat.utils.text import strip_metadata
+from vgj_chat.utils.text import drop_last_incomplete_paragraph, strip_metadata
 
 MODEL_DIR = pathlib.Path("/opt/ml/model")
 CACHE_DIR = pathlib.Path(os.environ.get("TRANSFORMERS_CACHE", "/tmp/hf_cache"))
@@ -104,7 +104,7 @@ def invoke(p: Prompt):
     answer_text = strip_metadata(
         TOKENIZER.decode(output[0][n_prompt:], skip_special_tokens=True).strip()
     )
-
+    answer_text = drop_last_incomplete_paragraph(answer_text)
 
     return {
         "generated_text": answer_text,

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,4 +1,4 @@
-from vgj_chat.utils.text import strip_metadata
+from vgj_chat.utils.text import drop_last_incomplete_paragraph, strip_metadata
 
 
 def test_strip_metadata_removes_sections():
@@ -11,3 +11,13 @@ def test_strip_metadata_removes_sections():
 def test_strip_metadata_handles_question_blocks():
     raw = "Great food available.\nQuestion: where?\nAnswer: here"
     assert strip_metadata(raw) == "Great food available."
+
+
+def test_drop_last_incomplete_paragraph_removes_truncated():
+    text = "First paragraph.\n\nSecond paragraph unfinished"
+    assert drop_last_incomplete_paragraph(text) == "First paragraph."
+
+
+def test_drop_last_incomplete_paragraph_keeps_complete():
+    text = "First paragraph.\n\nSecond paragraph finished."
+    assert drop_last_incomplete_paragraph(text) == text

--- a/vgj_chat/utils/text.py
+++ b/vgj_chat/utils/text.py
@@ -28,11 +28,10 @@ _CLEAN_TRANSLATION = {
     ord("\u201E"): '"',  # double low-9 quotation mark
     ord("\u201F"): '"',  # double high-reversed-9 quotation mark
     ord("\u2033"): '"',  # double prime (often inches)
-    ord("\u00AB"): '"',  # «
-    ord("\u00BB"): '"',  # »
-    ord("\u2039"): "'",  # ‹
-    ord("\u203A"): "'",  # ›
-
+    ord("\u00AB"): '"',  # Â«
+    ord("\u00BB"): '"',  # Â»
+    ord("\u2039"): "'",  # Â‹
+    ord("\u203A"): "'",  # Â›
     # Dashes / hyphens / minus
     ord("\u2010"): "-",  # hyphen
     ord("\u2011"): "-",  # non-breaking hyphen
@@ -42,16 +41,12 @@ _CLEAN_TRANSLATION = {
     ord("\u2015"): "-",  # horizontal bar
     ord("\u2212"): "-",  # minus sign (math minus -> hyphen-minus)
     ord("\u2043"): "-",  # hyphen bullet
-
     # Soft hyphen (discretionary) -> drop
     ord("\u00AD"): "",
-
     # Ellipsis
     ord("\u2026"): "...",
-
     # Fraction slash
     ord("\u2044"): "/",
-
     # Spaces -> regular space
     ord("\u00A0"): " ",  # no-break space
     ord("\u202F"): " ",  # narrow no-break space
@@ -68,13 +63,12 @@ _CLEAN_TRANSLATION = {
     ord("\u200A"): " ",  # hair space
     ord("\u205F"): " ",  # medium mathematical space
     ord("\u3000"): " ",  # ideographic space
-
     # Zero-width / joiners / BOM -> drop
-    ord("\u200B"): "",   # zero width space
-    ord("\u200C"): "",   # zero width non-joiner
-    ord("\u200D"): "",   # zero width joiner
-    ord("\u2060"): "",   # word joiner
-    ord("\uFEFF"): "",   # zero width no-break space (BOM)
+    ord("\u200B"): "",  # zero width space
+    ord("\u200C"): "",  # zero width non-joiner
+    ord("\u200D"): "",  # zero width joiner
+    ord("\u2060"): "",  # word joiner
+    ord("\uFEFF"): "",  # zero width no-break space (BOM)
 }
 
 
@@ -119,4 +113,30 @@ def clean_text(text: str) -> str:
     return text.strip()
 
 
-__all__ = ["token_len", "strip_metadata", "clean_text"]
+def drop_last_incomplete_paragraph(text: str) -> str:
+    """Remove the last paragraph if it ends mid sentence.
+
+    A paragraph is considered complete if it finishes with standard
+    sentence-ending punctuation (., !, or ?). If the final paragraph does
+    not end with such punctuation, it is dropped from the returned text.
+    """
+    if not text:
+        return ""
+    paragraphs = text.strip().split("\n\n")
+    while paragraphs and not paragraphs[-1].strip():
+        paragraphs.pop()
+    if not paragraphs:
+        return ""
+    last = paragraphs[-1].strip()
+    if re.search(r"[.!?][\"')\]]*$", last):
+        return "\n\n".join(paragraphs).strip()
+    paragraphs.pop()
+    return "\n\n".join(paragraphs).strip()
+
+
+__all__ = [
+    "token_len",
+    "strip_metadata",
+    "clean_text",
+    "drop_last_incomplete_paragraph",
+]


### PR DESCRIPTION
## Summary
- add `drop_last_incomplete_paragraph` text util to remove truncated final paragraph
- apply new cleanup step to generated answers in `serve.py`
- test new utility

## Testing
- `pre-commit run --files vgj_chat/utils/text.py serve.py tests/test_text_utils.py`
- `pytest` *(fails: No module named build; dataset tests)*

------
https://chatgpt.com/codex/tasks/task_e_6898a07baa788323a011696d10ea85e2