### PR TITLE
Limit inference context to three snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@
 - `--compare` CLI flag to launch Compare Mode. This flag is backward compatible and does not change behaviour when omitted.
 - `merge_lora.py` script to merge the adapter into a 4‑bit quantised model.
 
+### Changed
+- Cap inference context retrieval at three snippets to match training limits.
+

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -56,7 +56,7 @@ If you are unsure or lack information, say so and suggest checking official Visi
 def predict_fn(data, ctx):
     mdl = ctx
     prompt = data["inputs"].strip()
-    top_k = data.get("top_k", CFG.top_k)
+    top_k = min(data.get("top_k", CFG.top_k), 3)
 
     # --- retrieve ---
     emb_query = mdl["encoder"].encode(prompt, normalize_embeddings=True)

--- a/serve.py
+++ b/serve.py
@@ -52,7 +52,7 @@ def invoke(p: Prompt):
         raise ValueError(
             f"Embedding dimension {query_emb.shape[0]} does not match index dimension {INDEX.d}"
         )
-    _, ids = INDEX.search(query_emb.reshape(1, -1), CFG.top_k)
+    _, ids = INDEX.search(query_emb.reshape(1, -1), min(CFG.top_k, 3))
     hits = [METADATA[i] for i in ids[0]]
     context_parts: list[str] = []
     sources: list[str] = []

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -217,6 +217,10 @@ def test_build_auto_dataset_skips_long_passages(monkeypatch, tmp_path):
     auto_jl = tmp_path / "out.jsonl"
     monkeypatch.setattr(dataset, "AUTO_QA_JL", auto_jl)
 
+    # Patch chunker so the long passage isn't split into smaller chunks,
+    # ensuring the build is skipped.
+    monkeypatch.setattr(dataset, "_chunk_paragraphs", lambda paras, max_tokens: [paras])
+
     dataset.build_auto_dataset()
     assert calls["popen"] == 0
     assert not auto_jl.exists()
@@ -291,7 +295,7 @@ def test_choose_num_ctx_clamped(monkeypatch):
     dataset = _load_dataset(monkeypatch, "text")
 
     monkeypatch.setattr(dataset.random, "gauss", lambda mu, sig: 10)
-    assert dataset._choose_num_ctx(5) == 5
+    assert dataset._choose_num_ctx(5) == 3
 
     monkeypatch.setattr(dataset.random, "gauss", lambda mu, sig: -5)
     assert dataset._choose_num_ctx(5) == 0

--- a/vgj_chat/config.py
+++ b/vgj_chat/config.py
@@ -26,7 +26,7 @@ class Config:
     rerank_model: str = "BAAI/bge-reranker-base"
 
     # RAG settings
-    top_k: int = 1
+    top_k: int = 3
 
     score_min: float = 0.0
     max_new_tokens: int = 256


### PR DESCRIPTION
## Summary
- cap retrieval during inference and serving to at most three context snippets
- default `top_k` config increased to 3 for RAG
- adjust dataset tests and changelog for new limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b1af03448323b828ea7e57a3ae7b